### PR TITLE
idiomatic go

### DIFF
--- a/src/TibiaCharactersCharacterV3.go
+++ b/src/TibiaCharactersCharacterV3.go
@@ -216,11 +216,8 @@ func TibiaCharactersCharacterV3(c *gin.Context) {
 				regex1 := regexp.MustCompile(`<td.*class=.[a-zA-Z0-9_.-]+..*>(.*):<\/.*td><td>(.*)<\/td>`)
 				subma1 := regex1.FindAllStringSubmatch(CharacterTrHTML, -1)
 
-				var AccountStatusString = string([]byte{65, 99, 99, 111, 117, 110, 116, 194, 160, 83, 116, 97, 116, 117, 115})
-				var GuildMembershipString = string([]byte{71, 117, 105, 108, 100, 194, 160, 77, 101, 109, 98, 101, 114, 115, 104, 105, 112})
-
 				if len(subma1) > 0 {
-					switch subma1[0][1] {
+					switch TibiaDataSanitizeNbspSpaceString(subma1[0][1]) {
 					case "Name":
 						Tmp := strings.Split(subma1[0][2], "<")
 						CharacterInformationData.Name = strings.TrimSpace(Tmp[0])
@@ -254,7 +251,7 @@ func TibiaCharactersCharacterV3(c *gin.Context) {
 						CharacterInformationData.FormerWorlds = strings.Split(subma1[0][2], ", ")
 					case "Residence":
 						CharacterInformationData.Residence = subma1[0][2]
-					case AccountStatusString:
+					case "Account Status":
 						CharacterInformationData.AccountStatus = subma1[0][2]
 					case "Married To":
 						CharacterInformationData.MarriedTo = TibiadataRemoveURLsV3(subma1[0][2])
@@ -267,7 +264,7 @@ func TibiaCharactersCharacterV3(c *gin.Context) {
 							Paid:    TibiadataDateV3(subma1h[0][4]),
 							HouseID: TibiadataStringToIntegerV3(subma1h[0][1]),
 						})
-					case GuildMembershipString:
+					case "Guild Membership":
 						Tmp := strings.Split(subma1[0][2], " of the <a href=")
 						CharacterInformationData.Guild.Rank = Tmp[0]
 						CharacterInformationData.Guild.GuildName = TibiadataRemoveURLsV3("<a href=" + Tmp[1])

--- a/src/TibiaCharactersCharacterV3.go
+++ b/src/TibiaCharactersCharacterV3.go
@@ -164,32 +164,32 @@ func TibiaCharactersCharacterV3(c *gin.Context) {
 
 	// Running query on every .TableContainer
 	ReaderHTML.Find(".TableContainer").Each(func(index int, s *goquery.Selection) {
-
 		// Storing HTML into CharacterDivHTML
 		CharacterDivHTML, err := s.Html()
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		if strings.Contains(CharacterDivHTML, "Text\">Character Information") {
+		switch {
+		case strings.Contains(CharacterDivHTML, "Text\">Character Information"):
 			// Character Information
 			CharacterSection = "characterinformation"
-		} else if strings.Contains(CharacterDivHTML, "Text\">Account Badges") {
+		case strings.Contains(CharacterDivHTML, "Text\">Account Badges"):
 			// Account Badges
 			CharacterSection = "accountbadges"
-		} else if strings.Contains(CharacterDivHTML, "Text\">Account Achievements") {
+		case strings.Contains(CharacterDivHTML, "Text\">Account Achievements"):
 			// Account Achievements
 			CharacterSection = "accountachievements"
-		} else if strings.Contains(CharacterDivHTML, "Text\">Character Deaths") {
+		case strings.Contains(CharacterDivHTML, "Text\">Character Deaths"):
 			// Character Deaths
 			CharacterSection = "characterdeaths"
-		} else if strings.Contains(CharacterDivHTML, "Text\">Account Information") {
+		case strings.Contains(CharacterDivHTML, "Text\">Account Information"):
 			// Account Information
 			CharacterSection = "accountinformation"
-		} else if strings.Contains(CharacterDivHTML, "Text\">Search Character") {
+		case strings.Contains(CharacterDivHTML, "Text\">Search Character"):
 			// Search Character
 			CharacterSection = "searchcharacter"
-		} else if strings.Contains(CharacterDivHTML, "Text\">Characters") {
+		case strings.Contains(CharacterDivHTML, "Text\">Characters"):
 			// Characters
 			CharacterSection = "characters"
 		}
@@ -197,11 +197,10 @@ func TibiaCharactersCharacterV3(c *gin.Context) {
 		// parsing CharacterDivHTML to goquery format
 		CharacterDivQuery, _ := goquery.NewDocumentFromReader(strings.NewReader(CharacterDivHTML))
 
-		if CharacterSection == "characterinformation" || CharacterSection == "accountinformation" {
-
+		switch CharacterSection {
+		case "characterinformation", "accountinformation":
 			// Running query over each tr in character content container
 			CharacterDivQuery.Find(localDivQueryString).Each(func(index int, s *goquery.Selection) {
-
 				// Storing HTML into CharacterTrHTML
 				CharacterTrHTML, err := s.Html()
 				if err != nil {
@@ -217,9 +216,12 @@ func TibiaCharactersCharacterV3(c *gin.Context) {
 				regex1 := regexp.MustCompile(`<td.*class=.[a-zA-Z0-9_.-]+..*>(.*):<\/.*td><td>(.*)<\/td>`)
 				subma1 := regex1.FindAllStringSubmatch(CharacterTrHTML, -1)
 
-				if len(subma1) > 0 {
+				var AccountStatusString = string([]byte{65, 99, 99, 111, 117, 110, 116, 194, 160, 83, 116, 97, 116, 117, 115})
+				var GuildMembershipString = string([]byte{71, 117, 105, 108, 100, 194, 160, 77, 101, 109, 98, 101, 114, 115, 104, 105, 112})
 
-					if subma1[0][1] == "Name" {
+				if len(subma1) > 0 {
+					switch subma1[0][1] {
+					case "Name":
 						Tmp := strings.Split(subma1[0][2], "<")
 						CharacterInformationData.Name = strings.TrimSpace(Tmp[0])
 						if strings.Contains(Tmp[0], ", will be deleted at") {
@@ -231,33 +233,32 @@ func TibiaCharactersCharacterV3(c *gin.Context) {
 							CharacterInformationData.Traded = true
 							CharacterInformationData.Name = strings.Replace(CharacterInformationData.Name, localTradedString, "", -1)
 						}
-					} else if subma1[0][1] == "Former Names" {
+					case "Former Names":
 						CharacterInformationData.FormerNames = strings.Split(subma1[0][2], ", ")
-					} else if subma1[0][1] == "Sex" {
+					case "Sex":
 						CharacterInformationData.Sex = subma1[0][2]
-					} else if subma1[0][1] == "Title" {
+					case "Title":
 						regex1t := regexp.MustCompile(`(.*) \(([0-9]+).*`)
 						subma1t := regex1t.FindAllStringSubmatch(subma1[0][2], -1)
 						CharacterInformationData.Title = subma1t[0][1]
 						CharacterInformationData.UnlockedTitles = TibiadataStringToIntegerV3(subma1t[0][2])
-					} else if subma1[0][1] == "Vocation" {
+					case "Vocation":
 						CharacterInformationData.Vocation = subma1[0][2]
-					} else if subma1[0][1] == "Level" {
+					case "Level":
 						CharacterInformationData.Level = TibiadataStringToIntegerV3(subma1[0][2])
-					} else if subma1[0][1] == "Achievement Points" {
+					case "Achievement Points":
 						CharacterInformationData.AchievementPoints = TibiadataStringToIntegerV3(subma1[0][2])
-					} else if subma1[0][1] == "World" {
+					case "World":
 						CharacterInformationData.World = subma1[0][2]
-					} else if subma1[0][1] == "Former World" {
+					case "Former World":
 						CharacterInformationData.FormerWorlds = strings.Split(subma1[0][2], ", ")
-					} else if subma1[0][1] == "Residence" {
+					case "Residence":
 						CharacterInformationData.Residence = subma1[0][2]
-					} else if strings.Contains(subma1[0][1], "Account") && strings.Contains(subma1[0][1], "Status") {
-						// } else if subma1[0][1] == "Account Status" {
+					case AccountStatusString:
 						CharacterInformationData.AccountStatus = subma1[0][2]
-					} else if subma1[0][1] == "Married To" {
+					case "Married To":
 						CharacterInformationData.MarriedTo = TibiadataRemoveURLsV3(subma1[0][2])
-					} else if subma1[0][1] == "House" {
+					case "House":
 						regex1h := regexp.MustCompile(`.*houseid=([0-9]+).*character=.*>(.*)</a> \((.*)\) is paid until (.*)`)
 						subma1h := regex1h.FindAllStringSubmatch(subma1[0][2], -1)
 						CharacterInformationData.Houses = append(CharacterInformationData.Houses, Houses{
@@ -266,36 +267,31 @@ func TibiaCharactersCharacterV3(c *gin.Context) {
 							Paid:    TibiadataDateV3(subma1h[0][4]),
 							HouseID: TibiadataStringToIntegerV3(subma1h[0][1]),
 						})
-					} else if strings.Contains(subma1[0][1], "Guild") && strings.Contains(subma1[0][1], "Membership") {
-						// } else if subma1[0][1] == "Guild Membership" {
+					case GuildMembershipString:
 						Tmp := strings.Split(subma1[0][2], " of the <a href=")
 						CharacterInformationData.Guild.Rank = Tmp[0]
 						CharacterInformationData.Guild.GuildName = TibiadataRemoveURLsV3("<a href=" + Tmp[1])
-					} else if subma1[0][1] == "Last Login" {
+					case "Last Login":
 						if subma1[0][2] != "never logged in" {
 							CharacterInformationData.LastLogin = TibiadataDatetimeV3(subma1[0][2])
 						}
-					} else if subma1[0][1] == "Comment" {
+					case "Comment":
 						CharacterInformationData.Comment = strings.ReplaceAll(subma1[0][2], "<br/>", "\n")
-					} else if subma1[0][1] == "Loyalty Title" {
+					case "Loyalty Title":
 						AccountInformationData.LoyaltyTitle = subma1[0][2]
-					} else if subma1[0][1] == "Created" {
+					case "Created":
 						AccountInformationData.Created = TibiadataDatetimeV3(subma1[0][2])
-					} else if subma1[0][1] == "Position" {
+					case "Position":
 						TmpPosition := strings.Split(subma1[0][2], "<")
 						AccountInformationData.Position = strings.TrimSpace(TmpPosition[0])
-					} else {
+					default:
 						log.Println("LEFT OVER: `" + subma1[0][1] + "` = `" + subma1[0][2] + "`")
 					}
-
 				}
-
 			})
-
-		} else if CharacterSection == "accountbadges" {
+		case "accountbadges":
 			// Running query over each tr in list
 			CharacterDivQuery.Find(".TableContentContainer tr td").Each(func(index int, s *goquery.Selection) {
-
 				// Storing HTML into CharacterListHTML
 				CharacterListHTML, err := s.Html()
 				if err != nil {
@@ -315,11 +311,9 @@ func TibiaCharactersCharacterV3(c *gin.Context) {
 					Description: subma1[0][2],
 				})
 			})
-
-		} else if CharacterSection == "accountachievements" {
+		case "accountachievements":
 			// Running query over each tr in list
 			CharacterDivQuery.Find(localDivQueryString).Each(func(index int, s *goquery.Selection) {
-
 				// Storing HTML into CharacterListHTML
 				CharacterListHTML, err := s.Html()
 				if err != nil {
@@ -349,11 +343,9 @@ func TibiaCharactersCharacterV3(c *gin.Context) {
 				}
 
 			})
-
-		} else if CharacterSection == "characterdeaths" {
+		case "characterdeaths":
 			// Running query over each tr in list
 			CharacterDivQuery.Find(localDivQueryString).Each(func(index int, s *goquery.Selection) {
-
 				// Storing HTML into CharacterListHTML
 				CharacterListHTML, err := s.Html()
 				if err != nil {
@@ -439,15 +431,11 @@ func TibiaCharactersCharacterV3(c *gin.Context) {
 						Assists: DeathAssists,
 						Reason:  ReasonString,
 					})
-
 				}
-
 			})
-
-		} else if CharacterSection == "characters" {
+		case "characters":
 			// Running query over each tr in character list
 			CharacterDivQuery.Find(localDivQueryString).Each(func(index int, s *goquery.Selection) {
-
 				// Storing HTML into CharacterListHTML
 				CharacterListHTML, err := s.Html()
 				if err != nil {
@@ -462,7 +450,6 @@ func TibiaCharactersCharacterV3(c *gin.Context) {
 				subma1 := regex1.FindAllStringSubmatch(CharacterListHTML, -1)
 
 				if len(subma1) > 0 {
-
 					TmpCharacterName := subma1[0][1]
 
 					var TmpTraded bool
@@ -501,10 +488,8 @@ func TibiaCharactersCharacterV3(c *gin.Context) {
 						Traded:  TmpTraded,
 					})
 				}
-
 			})
 		}
-
 	})
 
 	//

--- a/src/TibiaCreaturesCreatureV3.go
+++ b/src/TibiaCreaturesCreatureV3.go
@@ -114,11 +114,11 @@ func TibiaCreaturesCreatureV3(c *gin.Context) {
 		if strings.Contains(subma1[0][4], "It takes ") && strings.Contains(subma1[0][4], " mana to ") {
 			regex24 := regexp.MustCompile(`.*It takes (.*) mana to (.*)`)
 			subma24 := regex24.FindAllStringSubmatch(subma1[0][4], -1)
-			subma24_0_2 := subma24[0][2]
-			if strings.Contains(subma24_0_2, "convince these creatures but they cannot be") {
+			subma2402 := subma24[0][2]
+			if strings.Contains(subma2402, "convince these creatures but they cannot be") {
 				CreatureBeConvinced = true
 				CreatureConvincedMana = TibiadataStringToIntegerV3(subma24[0][1])
-			} else if strings.Contains(subma24_0_2, "summon or convince these creatures") {
+			} else if strings.Contains(subma2402, "summon or convince these creatures") {
 				CreatureBeSummoned = true
 				CreatureSummonedMana = TibiadataStringToIntegerV3(subma24[0][1])
 				CreatureBeConvinced = true

--- a/src/TibiaCreaturesCreatureV3.go
+++ b/src/TibiaCreaturesCreatureV3.go
@@ -114,10 +114,11 @@ func TibiaCreaturesCreatureV3(c *gin.Context) {
 		if strings.Contains(subma1[0][4], "It takes ") && strings.Contains(subma1[0][4], " mana to ") {
 			regex24 := regexp.MustCompile(`.*It takes (.*) mana to (.*)`)
 			subma24 := regex24.FindAllStringSubmatch(subma1[0][4], -1)
-			if strings.Contains(subma24[0][2], "convince these creatures but they cannot be") {
+			subma24_0_2 := subma24[0][2]
+			if strings.Contains(subma24_0_2, "convince these creatures but they cannot be") {
 				CreatureBeConvinced = true
 				CreatureConvincedMana = TibiadataStringToIntegerV3(subma24[0][1])
-			} else if strings.Contains(subma24[0][2], "summon or convince these creatures") {
+			} else if strings.Contains(subma24_0_2, "summon or convince these creatures") {
 				CreatureBeSummoned = true
 				CreatureSummonedMana = TibiadataStringToIntegerV3(subma24[0][1])
 				CreatureBeConvinced = true

--- a/src/TibiaFansitesV3.go
+++ b/src/TibiaFansitesV3.go
@@ -101,13 +101,15 @@ func TibiaFansitesV3(c *gin.Context) {
 				imgs1 := imgRE1.FindAllStringSubmatch(subma1[0][5], -1)
 				out := make([]string, len(imgs1))
 				for i := range out {
-					if strings.Contains(imgs1[i][1], "Statistics") {
+					s := imgs1[i][1]
+					switch {
+					case strings.Contains(s, "Statistics"):
 						ContentTypeData.Statistics = true
-					} else if strings.Contains(imgs1[i][1], "ArticlesNews") {
+					case strings.Contains(s, "ArticlesNews"):
 						ContentTypeData.Texts = true
-					} else if strings.Contains(imgs1[i][1], "Tools") {
+					case strings.Contains(s, "Tools"):
 						ContentTypeData.Tools = true
-					} else if strings.Contains(imgs1[i][1], "Wiki") {
+					case strings.Contains(s, "Wiki"):
 						ContentTypeData.Wiki = true
 					}
 				}
@@ -118,19 +120,21 @@ func TibiaFansitesV3(c *gin.Context) {
 				imgs2 := imgRE2.FindAllStringSubmatch(subma1[0][6], -1)
 				out2 := make([]string, len(imgs2))
 				for i := range out2 {
-					if strings.Contains(imgs2[i][1], "Discord") {
+					s := imgs2[i][1]
+					switch {
+					case strings.Contains(s, "Discord"):
 						SocialMediaData.Discord = true
-					} else if strings.Contains(imgs2[i][1], "Facebook") {
+					case strings.Contains(s, "Facebook"):
 						SocialMediaData.Facebook = true
-					} else if strings.Contains(imgs2[i][1], "Instagram") {
+					case strings.Contains(s, "Instagram"):
 						SocialMediaData.Instagram = true
-					} else if strings.Contains(imgs2[i][1], "Reddit") {
+					case strings.Contains(s, "Reddit"):
 						SocialMediaData.Reddit = true
-					} else if strings.Contains(imgs2[i][1], "Twitch") {
+					case strings.Contains(s, "Twitch"):
 						SocialMediaData.Twitch = true
-					} else if strings.Contains(imgs2[i][1], "Twitter") {
+					case strings.Contains(s, "Twitter"):
 						SocialMediaData.Twitter = true
-					} else if strings.Contains(imgs2[i][1], "Youtube") {
+					case strings.Contains(s, "Youtube"):
 						SocialMediaData.Youtube = true
 					}
 				}
@@ -160,7 +164,8 @@ func TibiaFansitesV3(c *gin.Context) {
 					FansiteItemURLData = ""
 				}
 
-				if FansiteType == "promoted" {
+				switch FansiteType {
+				case "promoted":
 					PromotedFansitesData = append(PromotedFansitesData, Fansite{
 						Name:           subma1[0][3],
 						LogoURL:        subma1[0][2],
@@ -173,7 +178,7 @@ func TibiaFansitesV3(c *gin.Context) {
 						FansiteItem:    FansiteItemData,
 						FansiteItemURL: FansiteItemURLData,
 					})
-				} else if FansiteType == "supported" {
+				case "supported":
 					SupportedFansitesData = append(SupportedFansitesData, Fansite{
 						Name:           subma1[0][3],
 						LogoURL:        subma1[0][2],

--- a/src/TibiaSpellsOverviewV3.go
+++ b/src/TibiaSpellsOverviewV3.go
@@ -86,26 +86,28 @@ func TibiaSpellsOverviewV3(c *gin.Context) {
 
 		// check if regex return length is over 0 and the match of name is over 1
 		if len(subma1) > 0 {
-
 			// SpellGroup
 			GroupAttack = false
 			GroupHealing = false
 			GroupSupport = false
 
-			if subma1[0][4] == "Attack" {
+			switch subma1[0][4] {
+			case "Attack":
 				GroupAttack = true
-			} else if subma1[0][4] == "Healing" {
+			case "Healing":
 				GroupHealing = true
-			} else if subma1[0][4] == "Support" {
+			case "Support":
 				GroupSupport = true
 			}
 
 			// Type
 			TypeInstant = false
 			TypeRune = false
-			if subma1[0][5] == "Instant" {
+
+			switch subma1[0][5] {
+			case "Instant":
 				TypeInstant = true
-			} else if subma1[0][5] == "Rune" {
+			case "Rune":
 				TypeRune = true
 			}
 

--- a/src/TibiaSpellsSpellV3.go
+++ b/src/TibiaSpellsSpellV3.go
@@ -134,29 +134,33 @@ func TibiaSpellsSpellV3(c *gin.Context) {
 
 			// Vocation
 			if WorldsInformationLeftColumn == "Vocation" {
-				if SpellInformationSection == "spell" {
+				switch SpellInformationSection {
+				case "spell":
 					SpellsInfoVocation = strings.Split(WorldsInformationRightColumn, ", ")
-				} else if SpellInformationSection == "rune" {
+				case "rune":
 					RuneInfoVocation = strings.Split(WorldsInformationRightColumn, ", ")
 				}
 			}
 
 			// Group information
 			if WorldsInformationLeftColumn == "Group" {
-				if SpellInformationSection == "spell" {
-					if WorldsInformationRightColumn == "Attack" {
+				switch SpellInformationSection {
+				case "spell":
+					switch WorldsInformationRightColumn {
+					case "Attack":
 						SpellsInfoGroupAttack = true
-					} else if WorldsInformationRightColumn == "Healing" {
+					case "Healing":
 						SpellsInfoGroupHealing = true
-					} else if WorldsInformationRightColumn == "Support" {
+					case "Support":
 						SpellsInfoGroupSupport = true
 					}
-				} else if SpellInformationSection == "rune" {
-					if WorldsInformationRightColumn == "Attack" {
+				case "rune":
+					switch WorldsInformationRightColumn {
+					case "Attack":
 						RuneInfoGroupAttack = true
-					} else if WorldsInformationRightColumn == "Healing" {
+					case "Healing":
 						RuneInfoGroupHealing = true
-					} else if WorldsInformationRightColumn == "Support" {
+					case "Support":
 						RuneInfoGroupSupport = true
 					}
 				}
@@ -164,18 +168,20 @@ func TibiaSpellsSpellV3(c *gin.Context) {
 
 			// Spell type
 			if WorldsInformationLeftColumn == "Type" {
-				if WorldsInformationRightColumn == "Instant" {
+				switch WorldsInformationRightColumn {
+				case "Instant":
 					SpellsInfoTypeInstant = true
-				} else if WorldsInformationRightColumn == "Rune" {
+				case "Rune":
 					SpellsInfoTypeRune = true
 				}
 			}
 
 			// Damage
 			if WorldsInformationLeftColumn == "Damage Type" {
-				if SpellInformationSection == "spell" {
+				switch SpellInformationSection {
+				case "spell":
 					SpellsInfoDamageType = strings.ToLower(WorldsInformationRightColumn)
-				} else if SpellInformationSection == "rune" {
+				case "rune":
 					RuneInfoDamageType = strings.ToLower(WorldsInformationRightColumn)
 				}
 			}
@@ -203,9 +209,10 @@ func TibiaSpellsSpellV3(c *gin.Context) {
 
 			// Experience Level
 			if WorldsInformationLeftColumn == "Exp Lvl" {
-				if SpellInformationSection == "spell" {
+				switch SpellInformationSection {
+				case "spell":
 					SpellsInfoLevel = TibiadataStringToIntegerV3(WorldsInformationRightColumn)
-				} else if SpellInformationSection == "rune" {
+				case "rune":
 					RuneInfoLevel = TibiadataStringToIntegerV3(WorldsInformationRightColumn)
 				}
 			}

--- a/src/TibiaWorldsOverviewV3.go
+++ b/src/TibiaWorldsOverviewV3.go
@@ -98,11 +98,12 @@ func TibiaWorldsOverviewV3(c *gin.Context) {
 
 			// Setting the players_online & overall players_online
 			WorldsAllOnlinePlayers += WorldsPlayersOnline
-			if WorldsPlayersOnline > 0 {
+			switch {
+			case WorldsPlayersOnline > 0:
 				WorldsStatus = "online"
-			} else if subma2[0][2] == "-" {
+			case subma2[0][2] == "-":
 				WorldsStatus = "unknown"
-			} else {
+			default:
 				WorldsStatus = "offline"
 			}
 
@@ -146,9 +147,10 @@ func TibiaWorldsOverviewV3(c *gin.Context) {
 			}
 
 			// Setting the tournament_world_type param
-			if WorldsWorldCategory == "regular" {
+			switch WorldsWorldCategory {
+			case "regular":
 				WorldsTournamentWorldType = ""
-			} else if WorldsWorldCategory == "tournament" {
+			case "tournament":
 				WorldsGameWorldType = "tournament"
 				WorldsTournamentWorldType = "regular"
 				if strings.Contains(WorldsAdditionalInfo, "restricted") {
@@ -172,12 +174,12 @@ func TibiaWorldsOverviewV3(c *gin.Context) {
 			}
 
 			// Adding OneWorld to correct category
-			if WorldsWorldCategory == "regular" {
+			switch WorldsWorldCategory {
+			case "regular":
 				RegularWorldsData = append(RegularWorldsData, OneWorld)
-			} else if WorldsWorldCategory == "tournament" {
+			case "tournament":
 				TournamentWorldsData = append(TournamentWorldsData, OneWorld)
 			}
-
 		}
 	})
 

--- a/src/TibiaWorldsWorldV3.go
+++ b/src/TibiaWorldsWorldV3.go
@@ -93,11 +93,12 @@ func TibiaWorldsWorldV3(c *gin.Context) {
 			WorldsInformationRightColumn := TibiaDataSanitizeEscapedString(subma1[0][2])
 
 			if WorldsInformationLeftColumn == "Status" {
-				if strings.Contains(WorldsInformationRightColumn, "</div>Online") {
+				switch {
+				case strings.Contains(WorldsInformationRightColumn, "</div>Online"):
 					WorldsStatus = "online"
-				} else if strings.Contains(WorldsInformationRightColumn, "</div>Offline") {
+				case strings.Contains(WorldsInformationRightColumn, "</div>Offline"):
 					WorldsStatus = "offline"
-				} else {
+				default:
 					WorldsStatus = "unknown"
 				}
 			}

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -450,6 +450,11 @@ func TibiaDataSanitizeDoubleQuoteString(data string) string {
 	return strings.ReplaceAll(data, "\"", "'")
 }
 
+// TibiaDataSanitizeNbspSpaceString func - replaces weird \u00A0 string to real space
+func TibiaDataSanitizeNbspSpaceString(data string) string {
+	return strings.ReplaceAll(data, "\u00A0", " ")
+}
+
 // getEnv func - read an environment or return a default value
 func getEnv(key string, defaultVal string) string {
 	if value, exists := os.LookupEnv(key); exists {


### PR DESCRIPTION
As per https://go.dev/doc/effective_go#switch, in go it is idiomatic to use switch cases over else if's. 
In this PR I aim to move all cases of else ifs that I found to be better suited with switch cases. 

I also saw that Tibia's website has a weird format for the `Account Status` and `Guild Membership` data, and you used `strings.Contains` for those. In case for it to be better suited with the switch case, I instead used an array of bytes (converted to a string) that exactly matches the output of Tibia's data and compare against that. 

Let me know what you think :) 