### PR TITLE
fix highscores endpoints

### DIFF
--- a/src/webserver.go
+++ b/src/webserver.go
@@ -121,10 +121,10 @@ func main() {
 
 		// Tibia highscores
 		v3.GET("/highscores/world/:world", func(c *gin.Context) {
-			c.Redirect(http.StatusMovedPermanently, v3.BasePath()+"/highscores/"+c.Param("world")+"/experience/"+TibiadataDefaultVoc)
+			c.Redirect(http.StatusMovedPermanently, v3.BasePath()+"/highscores/world/"+c.Param("world")+"/experience/"+TibiadataDefaultVoc)
 		})
 		v3.GET("/highscores/world/:world/:category", func(c *gin.Context) {
-			c.Redirect(http.StatusMovedPermanently, v3.BasePath()+"/highscores/"+c.Param("world")+"/"+c.Param("category")+"/"+TibiadataDefaultVoc)
+			c.Redirect(http.StatusMovedPermanently, v3.BasePath()+"/highscores/world/"+c.Param("world")+"/"+c.Param("category")+"/"+TibiadataDefaultVoc)
 		})
 		v3.GET("/highscores/world/:world/:category/:vocation", TibiaHighscoresV3)
 


### PR DESCRIPTION
Currently `/highscores/world/:world` and `/highscores/world/:world/:category"` are incorrectly redirecting.

Instead of redirecting to `/highscores/world/:world/:category/:vocation`, they are redirecting to `/highscores/:world/:category/:vocation`.