### PR TITLE
Guilds name upper casing correction

### DIFF
--- a/src/TibiaGuildsGuildV3.go
+++ b/src/TibiaGuildsGuildV3.go
@@ -121,17 +121,13 @@ func TibiaGuildsGuildV3(c *gin.Context) {
 	var GuildDescriptionFinished bool
 	for _, line := range strings.Split(strings.TrimSuffix(InnerTableContainerTMPB, "\n"), "\n") {
 
-		log.Println(line)
-
 		// Guild information
 		if !GuildDescriptionFinished {
 			// First line is the description..
 			GuildDescription += strings.ReplaceAll(line+"\n", "<br/><br/>\n", "")
-			log.Println(GuildDescription)
 
 			// Abort loop and continue wiht next section
 			if strings.Contains(line, "<br/><br/>") {
-				guild = GuildDescription
 				GuildDescription = TibiaDataSanitizeEscapedString(GuildDescription)
 				GuildDescriptionFinished = true
 			}

--- a/src/TibiaGuildsGuildV3.go
+++ b/src/TibiaGuildsGuildV3.go
@@ -118,8 +118,14 @@ func TibiaGuildsGuildV3(c *gin.Context) {
 		log.Fatal(err)
 	}
 
-	var GuildDescriptionFinished bool
+	var GuildNameDetected, GuildDescriptionFinished bool
 	for _, line := range strings.Split(strings.TrimSuffix(InnerTableContainerTMPB, "\n"), "\n") {
+
+		// setting guild name based on html
+		if !GuildNameDetected {
+			guild = strings.TrimSpace(RemoveHtmlTag(line))
+			GuildNameDetected = true
+		}
 
 		// Guild information
 		if !GuildDescriptionFinished {

--- a/src/TibiaGuildsGuildV3.go
+++ b/src/TibiaGuildsGuildV3.go
@@ -128,7 +128,7 @@ func TibiaGuildsGuildV3(c *gin.Context) {
 
 			// Abort loop and continue wiht next section
 			if strings.Contains(line, "<br/><br/>") {
-				GuildDescription = TibiaDataSanitizeEscapedString(GuildDescription)
+				GuildDescription = strings.TrimSpace(TibiaDataSanitizeEscapedString(GuildDescription))
 				GuildDescriptionFinished = true
 			}
 

--- a/src/TibiaGuildsOverviewV3.go
+++ b/src/TibiaGuildsOverviewV3.go
@@ -85,7 +85,7 @@ func TibiaGuildsOverviewV3(c *gin.Context) {
 
 				// Check if there's a description to fetch.
 				if nameAndDescriptionNode.FirstChild.NextSibling != nil && nameAndDescriptionNode.FirstChild.NextSibling.NextSibling != nil {
-					description = nameAndDescriptionNode.FirstChild.NextSibling.NextSibling.Data
+					description = strings.TrimSpace(nameAndDescriptionNode.FirstChild.NextSibling.NextSibling.Data)
 				}
 
 				OneGuild := Guild{


### PR DESCRIPTION
- removing log printing (accidentally added with #34)
- adding trim of guild description 
- using guild name based on html response (so we get correct upper and lower letters in name)