### PR TITLE
Adding rate-limit detection and status code switching

### DIFF
--- a/src/TibiaCharactersCharacterV3.go
+++ b/src/TibiaCharactersCharacterV3.go
@@ -154,9 +154,9 @@ func TibiaCharactersCharacterV3(c *gin.Context) {
 	TibiadataRequest.URL = "https://www.tibia.com/community/?subtopic=characters&name=" + TibiadataQueryEscapeStringV3(character)
 	BoxContentHTML, err := TibiadataHTMLDataCollectorV3(TibiadataRequest)
 
-	// return error (e.g.1 for maintenance mode)
+	// return error (e.g. for maintenance mode)
 	if err != nil {
-		TibiaDataAPIHandleOtherResponse(c, http.StatusServiceUnavailable, "TibiaCharactersCharacterV3", gin.H{"error": err.Error()})
+		TibiaDataAPIHandleOtherResponse(c, http.StatusBadGateway, "TibiaCharactersCharacterV3", gin.H{"error": err.Error()})
 		return
 	}
 

--- a/src/TibiaCreaturesCreatureV3.go
+++ b/src/TibiaCreaturesCreatureV3.go
@@ -53,9 +53,9 @@ func TibiaCreaturesCreatureV3(c *gin.Context) {
 	TibiadataRequest.URL = "https://www.tibia.com/library/?subtopic=creatures&race=" + TibiadataQueryEscapeStringV3(race)
 	BoxContentHTML, err := TibiadataHTMLDataCollectorV3(TibiadataRequest)
 
-	// return error (e.g.1 for maintenance mode)
+	// return error (e.g. for maintenance mode)
 	if err != nil {
-		TibiaDataAPIHandleOtherResponse(c, http.StatusServiceUnavailable, "TibiaCreaturesCreatureV3", gin.H{"error": err.Error()})
+		TibiaDataAPIHandleOtherResponse(c, http.StatusBadGateway, "TibiaCreaturesCreatureV3", gin.H{"error": err.Error()})
 		return
 	}
 

--- a/src/TibiaCreaturesOverviewV3.go
+++ b/src/TibiaCreaturesOverviewV3.go
@@ -38,9 +38,9 @@ func TibiaCreaturesOverviewV3(c *gin.Context) {
 	TibiadataRequest.URL = "https://www.tibia.com/library/?subtopic=creatures"
 	BoxContentHTML, err := TibiadataHTMLDataCollectorV3(TibiadataRequest)
 
-	// return error (e.g.1 for maintenance mode)
+	// return error (e.g. for maintenance mode)
 	if err != nil {
-		TibiaDataAPIHandleOtherResponse(c, http.StatusServiceUnavailable, "TibiaCreaturesOverviewV3", gin.H{"error": err.Error()})
+		TibiaDataAPIHandleOtherResponse(c, http.StatusBadGateway, "TibiaCreaturesOverviewV3", gin.H{"error": err.Error()})
 		return
 	}
 

--- a/src/TibiaFansitesV3.go
+++ b/src/TibiaFansitesV3.go
@@ -62,9 +62,9 @@ func TibiaFansitesV3(c *gin.Context) {
 	TibiadataRequest.URL = "https://www.tibia.com/community/?subtopic=fansites"
 	BoxContentHTML, err := TibiadataHTMLDataCollectorV3(TibiadataRequest)
 
-	// return error (e.g.1 for maintenance mode)
+	// return error (e.g. for maintenance mode)
 	if err != nil {
-		TibiaDataAPIHandleOtherResponse(c, http.StatusServiceUnavailable, "TibiaFansitesV3", gin.H{"error": err.Error()})
+		TibiaDataAPIHandleOtherResponse(c, http.StatusBadGateway, "TibiaFansitesV3", gin.H{"error": err.Error()})
 		return
 	}
 

--- a/src/TibiaGuildsGuildV3.go
+++ b/src/TibiaGuildsGuildV3.go
@@ -91,9 +91,9 @@ func TibiaGuildsGuildV3(c *gin.Context) {
 	TibiadataRequest.URL = "https://www.tibia.com/community/?subtopic=guilds&page=view&GuildName=" + TibiadataQueryEscapeStringV3(guild)
 	BoxContentHTML, err := TibiadataHTMLDataCollectorV3(TibiadataRequest)
 
-	// return error (e.g.1 for maintenance mode)
+	// return error (e.g. for maintenance mode)
 	if err != nil {
-		TibiaDataAPIHandleOtherResponse(c, http.StatusServiceUnavailable, "TibiaGuildsGuildV3", gin.H{"error": err.Error()})
+		TibiaDataAPIHandleOtherResponse(c, http.StatusBadGateway, "TibiaGuildsGuildV3", gin.H{"error": err.Error()})
 		return
 	}
 

--- a/src/TibiaGuildsOverviewV3.go
+++ b/src/TibiaGuildsOverviewV3.go
@@ -47,9 +47,9 @@ func TibiaGuildsOverviewV3(c *gin.Context) {
 	TibiadataRequest.URL = "https://www.tibia.com/community/?subtopic=guilds&world=" + TibiadataQueryEscapeStringV3(world)
 	BoxContentHTML, err := TibiadataHTMLDataCollectorV3(TibiadataRequest)
 
-	// return error (e.g.1 for maintenance mode)
+	// return error (e.g. for maintenance mode)
 	if err != nil {
-		TibiaDataAPIHandleOtherResponse(c, http.StatusServiceUnavailable, "TibiaGuildsOverviewV3", gin.H{"error": err.Error()})
+		TibiaDataAPIHandleOtherResponse(c, http.StatusBadGateway, "TibiaGuildsOverviewV3", gin.H{"error": err.Error()})
 		return
 	}
 

--- a/src/TibiaHighscoresV3.go
+++ b/src/TibiaHighscoresV3.go
@@ -114,9 +114,9 @@ func TibiaHighscoresV3(c *gin.Context) {
 	TibiadataRequest.URL = "https://www.tibia.com/community/?subtopic=highscores&world=" + TibiadataQueryEscapeStringV3(world) + "&category=" + TibiadataQueryEscapeStringV3(categoryid) + "&profession=" + TibiadataQueryEscapeStringV3(vocationid) + "&currentpage=400000000000000"
 	BoxContentHTML, err := TibiadataHTMLDataCollectorV3(TibiadataRequest)
 
-	// return error (e.g.1 for maintenance mode)
+	// return error (e.g. for maintenance mode)
 	if err != nil {
-		TibiaDataAPIHandleOtherResponse(c, http.StatusServiceUnavailable, "TibiaHighscoresV3", gin.H{"error": err.Error()})
+		TibiaDataAPIHandleOtherResponse(c, http.StatusBadGateway, "TibiaHighscoresV3", gin.H{"error": err.Error()})
 		return
 	}
 

--- a/src/TibiaKillstatisticsV3.go
+++ b/src/TibiaKillstatisticsV3.go
@@ -54,9 +54,9 @@ func TibiaKillstatisticsV3(c *gin.Context) {
 	TibiadataRequest.URL = "https://www.tibia.com/community/?subtopic=killstatistics&world=" + TibiadataQueryEscapeStringV3(world)
 	BoxContentHTML, err := TibiadataHTMLDataCollectorV3(TibiadataRequest)
 
-	// return error (e.g.1 for maintenance mode)
+	// return error (e.g. for maintenance mode)
 	if err != nil {
-		TibiaDataAPIHandleOtherResponse(c, http.StatusServiceUnavailable, "TibiaKillstatisticsV3", gin.H{"error": err.Error()})
+		TibiaDataAPIHandleOtherResponse(c, http.StatusBadGateway, "TibiaKillstatisticsV3", gin.H{"error": err.Error()})
 		return
 	}
 

--- a/src/TibiaSpellsOverviewV3.go
+++ b/src/TibiaSpellsOverviewV3.go
@@ -63,9 +63,9 @@ func TibiaSpellsOverviewV3(c *gin.Context) {
 	TibiadataRequest.URL = "https://www.tibia.com/library/?subtopic=spells&vocation=" + TibiadataQueryEscapeStringV3(vocationName)
 	BoxContentHTML, err := TibiadataHTMLDataCollectorV3(TibiadataRequest)
 
-	// return error (e.g.1 for maintenance mode)
+	// return error (e.g. for maintenance mode)
 	if err != nil {
-		TibiaDataAPIHandleOtherResponse(c, http.StatusServiceUnavailable, "TibiaSpellsOverviewV3", gin.H{"error": err.Error()})
+		TibiaDataAPIHandleOtherResponse(c, http.StatusBadGateway, "TibiaSpellsOverviewV3", gin.H{"error": err.Error()})
 		return
 	}
 

--- a/src/TibiaSpellsSpellV3.go
+++ b/src/TibiaSpellsSpellV3.go
@@ -79,9 +79,9 @@ func TibiaSpellsSpellV3(c *gin.Context) {
 	TibiadataRequest.URL = "https://www.tibia.com/library/?subtopic=spells&spell=" + TibiadataQueryEscapeStringV3(spell)
 	BoxContentHTML, err := TibiadataHTMLDataCollectorV3(TibiadataRequest)
 
-	// return error (e.g.1 for maintenance mode)
+	// return error (e.g. for maintenance mode)
 	if err != nil {
-		TibiaDataAPIHandleOtherResponse(c, http.StatusServiceUnavailable, "TibiaSpellsSpellV3", gin.H{"error": err.Error()})
+		TibiaDataAPIHandleOtherResponse(c, http.StatusBadGateway, "TibiaSpellsSpellV3", gin.H{"error": err.Error()})
 		return
 	}
 

--- a/src/TibiaWorldsOverviewV3.go
+++ b/src/TibiaWorldsOverviewV3.go
@@ -48,9 +48,9 @@ func TibiaWorldsOverviewV3(c *gin.Context) {
 	TibiadataRequest.URL = "https://www.tibia.com/community/?subtopic=worlds"
 	BoxContentHTML, err := TibiadataHTMLDataCollectorV3(TibiadataRequest)
 
-	// return error (e.g.1 for maintenance mode)
+	// return error (e.g. for maintenance mode)
 	if err != nil {
-		TibiaDataAPIHandleOtherResponse(c, http.StatusServiceUnavailable, "TibiaWorldsOverviewV3", gin.H{"error": err.Error()})
+		TibiaDataAPIHandleOtherResponse(c, http.StatusBadGateway, "TibiaWorldsOverviewV3", gin.H{"error": err.Error()})
 		return
 	}
 

--- a/src/TibiaWorldsWorldV3.go
+++ b/src/TibiaWorldsWorldV3.go
@@ -62,9 +62,9 @@ func TibiaWorldsWorldV3(c *gin.Context) {
 	TibiadataRequest.URL = "https://www.tibia.com/community/?subtopic=worlds&world=" + TibiadataQueryEscapeStringV3(world)
 	BoxContentHTML, err := TibiadataHTMLDataCollectorV3(TibiadataRequest)
 
-	// return error (e.g.1 for maintenance mode)
+	// return error (e.g. for maintenance mode)
 	if err != nil {
-		TibiaDataAPIHandleOtherResponse(c, http.StatusServiceUnavailable, "TibiaWorldsWorldV3", gin.H{"error": err.Error()})
+		TibiaDataAPIHandleOtherResponse(c, http.StatusBadGateway, "TibiaWorldsWorldV3", gin.H{"error": err.Error()})
 		return
 	}
 


### PR DESCRIPTION
- adding rate-limit detection on `403`, if there are too many requests being sent to upstream
- changing response error code when maintenance from `503` to `502` (rel #34)