### PR TITLE
clean up webserver.go

### DIFF
--- a/src/TibiaDataUtils.go
+++ b/src/TibiaDataUtils.go
@@ -1,9 +1,18 @@
 package main
 
 import (
+	"html"
+	"io"
 	"log"
+	"net/url"
+	"os"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
 	"time"
 
+	"golang.org/x/text/encoding/charmap"
 	"golang.org/x/text/unicode/norm"
 )
 
@@ -41,4 +50,191 @@ func TibiadataDatetimeV3(date string) string {
 
 	// Return of formatted date and time string to functions..
 	return returnDate.UTC().Format(time.RFC3339)
+}
+
+// TibiadataHTMLRemoveLinebreaksV3 func
+func TibiadataHTMLRemoveLinebreaksV3(data string) string {
+	return strings.ReplaceAll(data, "\n", "")
+}
+
+var removeUrlRegex = regexp.MustCompile(`<a.*>(.*)<\/a>`)
+
+// TibiadataRemoveURLsV3 func
+func TibiadataRemoveURLsV3(data string) string {
+	// prepare return value
+	var returnData string
+
+	result := removeUrlRegex.FindAllStringSubmatch(data, -1)
+
+	if len(result) > 0 {
+		returnData = result[0][1]
+	} else {
+		returnData = ""
+	}
+
+	return returnData
+}
+
+// TibiadataStringWorldFormatToTitleV3 func
+func TibiadataStringWorldFormatToTitleV3(world string) string {
+	return strings.Title(strings.ToLower(world))
+}
+
+// TibiadataQueryEscapeStringV3 func - encode string to be correct formatted
+func TibiadataQueryEscapeStringV3(data string) string {
+	// switching "+" to " "
+	data = strings.ReplaceAll(data, "+", " ")
+
+	// encoding string to latin-1
+	data, _ = TibiaDataConvertEncodingtoISO88591(data)
+
+	// returning with QueryEscape function
+	return url.QueryEscape(data)
+}
+
+var dateRegex = regexp.MustCompile(`([a-zA-Z]{3}).*([0-9]{2}).*([0-9]{4})`)
+
+// TibiadataDateV3 func
+func TibiadataDateV3(date string) string {
+	// use regex to skip weird formatting on "spaces"
+	subma1 := dateRegex.FindAllStringSubmatch(date, -1)
+	date = (subma1[0][1] + " " + subma1[0][2] + " " + subma1[0][3])
+
+	// parsing and setting format of return
+	tmpDate, _ := time.Parse("Jan 02 2006", date)
+	date = tmpDate.UTC().Format("2006-01-02")
+
+	return date
+}
+
+// TibiadataStringToIntegerV3 func
+func TibiadataStringToIntegerV3(data string) int {
+	returnData, err := strconv.Atoi(data)
+	if err != nil {
+		log.Printf("[warning] TibiadataStringToIntegerV3: couldn't convert %s into an int. error: %s", data, err)
+	}
+
+	return returnData
+}
+
+var removeHtmlTagRegex = regexp.MustCompile(`(<\/?[a-zA-A]+?[^>]*\/?>)*`)
+
+// match html tag and replace it with ""
+func RemoveHtmlTag(in string) string {
+	groups := removeHtmlTagRegex.FindAllString(in, -1)
+	// should replace long string first
+	sort.Slice(groups, func(i, j int) bool {
+		return len(groups[i]) > len(groups[j])
+	})
+
+	for _, group := range groups {
+		if strings.TrimSpace(group) != "" {
+			in = strings.ReplaceAll(in, group, "")
+		}
+	}
+
+	return in
+}
+
+// TibiaDataConvertEncodingtoISO88591 func - convert string from UTF-8 to latin1 (ISO 8859-1)
+func TibiaDataConvertEncodingtoISO88591(data string) (string, error) {
+	return charmap.ISO8859_1.NewEncoder().String(data)
+}
+
+// TibiaDataConvertEncodingtoUTF8 func - convert string from latin1 (ISO 8859-1) to UTF-8
+func TibiaDataConvertEncodingtoUTF8(data io.Reader) io.Reader {
+	return norm.NFKC.Reader(charmap.ISO8859_1.NewDecoder().Reader(data))
+}
+
+// isEnvExist func - check if environment var is set
+func isEnvExist(key string) bool {
+	if _, ok := os.LookupEnv(key); ok {
+		return true
+	}
+
+	return false
+}
+
+// TibiaDataSanitizeEscapedString func - run unescape string on string
+func TibiaDataSanitizeEscapedString(data string) string {
+	return html.UnescapeString(data)
+}
+
+// TibiaDataSanitizeDoubleQuoteString func - replaces double quotes to single quotes in strings
+func TibiaDataSanitizeDoubleQuoteString(data string) string {
+	return strings.ReplaceAll(data, "\"", "'")
+}
+
+// TibiaDataSanitizeNbspSpaceString func - replaces weird \u00A0 string to real space
+func TibiaDataSanitizeNbspSpaceString(data string) string {
+	return strings.ReplaceAll(data, "\u00A0", " ")
+}
+
+// getEnv func - read an environment or return a default value
+func getEnv(key string, defaultVal string) string {
+	if value, exists := os.LookupEnv(key); exists {
+		return value
+	}
+
+	return defaultVal
+}
+
+// getEnvAsBool func - read an environment variable into a bool or return default value
+func getEnvAsBool(name string, defaultVal bool) bool {
+	valStr := getEnv(name, "")
+	if val, err := strconv.ParseBool(valStr); err == nil {
+		return val
+	}
+
+	return defaultVal
+}
+
+/*
+// getEnvAsFloat func - read an environment variable into a float64 or return default value
+func getEnvAsFloat(name string, defaultVal float64) float64 {
+	valStr := getEnv(name, "")
+	if val, err := strconv.ParseFloat(valStr, 64); err == nil {
+		return val
+	}
+	return defaultVal
+}
+
+// getEnvAsInt func - read an environment variable into integer or return a default value
+func getEnvAsInt(name string, defaultVal int) int {
+	valueStr := getEnv(name, "")
+	if value, err := strconv.Atoi(valueStr); err == nil {
+		return value
+	}
+	return defaultVal
+}
+*/
+
+// TibiaDataVocationValidator func - return valid vocation string and vocation id
+func TibiaDataVocationValidator(vocation string) (string, string) {
+	// defining return vars
+	var vocationid string
+
+	switch strings.ToLower(vocation) {
+	case "none":
+		vocationid = "1"
+		vocation = "none"
+	case "knight", "knights":
+		vocationid = "2"
+		vocation = "knights"
+	case "paladin", "paladins":
+		vocationid = "3"
+		vocation = "paladins"
+	case "sorcerer", "sorcerers":
+		vocationid = "4"
+		vocation = "sorcerers"
+	case "druid", "druids":
+		vocationid = "5"
+		vocation = "druids"
+	default:
+		vocationid = "0"
+		vocation = "all"
+	}
+
+	// returning vars
+	return vocation, vocationid
 }

--- a/src/main.go
+++ b/src/main.go
@@ -1,0 +1,73 @@
+package main
+
+import "log"
+
+var (
+	// TibiadataDefaultVoc - default vocation when not specified in request
+	TibiadataDefaultVoc string = "all"
+
+	// Tibiadata app flags for running
+	TibiadataAPIversion int = 3
+	TibiadataDebug      bool
+
+	// Tibiadata app settings
+	TibiadataHost string // set through env TIBIADATA_HOST
+
+	// Tibiadata app details set to release/build on GitHub
+	TibiadataBuildRelease = "unknown"     // will be set by GitHub Actions (to release number)
+	TibiadataBuildBuilder = "manual"      // will be set by GitHub Actions
+	TibiadataBuildCommit  = "-"           // will be set by GitHub Actions (to git commit)
+	TibiadataBuildEdition = "open-source" //
+)
+
+func main() {
+	// logging start of TibiaData
+	log.Printf("[info] TibiaData API starting..")
+
+	// running the TibiaDataInitializer function
+	TibiaDataInitializer()
+
+	// logging build information
+	log.Printf("[info] TibiaData API release: %s", TibiadataBuildRelease)
+	log.Printf("[info] TibiaData API build: %s", TibiadataBuildBuilder)
+	log.Printf("[info] TibiaData API commit: %s", TibiadataBuildCommit)
+	log.Printf("[info] TibiaData API edition: %s", TibiadataBuildEdition)
+
+	// setting tibiadata-application to log much less if DEBUG_MODE is false (default is false)
+	if !getEnvAsBool("DEBUG_MODE", false) {
+		log.Printf("[info] TibiaData API debug-mode: disabled")
+	} else {
+		// setting debug to true for more logging
+		TibiadataDebug = true
+		log.Printf("[info] TibiaData API debug-mode: enabled")
+
+		// logging user-agent string
+		log.Printf("[debug] TIbiaData API User-Agent: %s", TibiadataUserAgent)
+	}
+
+	runWebServer()
+}
+
+// TibiaDataInitializer func - init things at beginning
+func TibiaDataInitializer() {
+	// setting TibiadataBuildEdition
+	if isEnvExist("TIBIADATA_EDITION") {
+		TibiadataBuildEdition = getEnv("TIBIADATA_EDITION", "open-source")
+	}
+
+	// adding information of host
+	TibiadataHost = getEnv("TIBIADATA_HOST", "")
+	if TibiadataHost != "" {
+		TibiadataHost = "+https://" + TibiadataHost
+	}
+
+	// generating TibiadataUserAgent with TibiadataUserAgentGenerator function
+	TibiadataUserAgent = TibiadataUserAgentGenerator(TibiadataAPIversion)
+
+	// setting TibiadataProxyDomain
+	if isEnvExist("TIBIADATA_PROXY") {
+		TibiadataProxyDomain = "https://" + getEnv("TIBIADATA_PROXY", "www.tibia.com") + "/"
+	}
+
+	log.Printf("[info] TibiaData API proxy: %s", TibiadataProxyDomain)
+}


### PR DESCRIPTION
Hi!

Just for organization purposes, I decided to split `webserver.go` into 3 differente files: `webserver.go`, `main.go` and `TibiaDataUtils.go`. (`TibiaDatautils.go` already existed, I just added more functions to it).

The reason for this is that the `main` function, as well as some utility functions were all in `webserver.go`. I just moved the functions already.

There is no logic change in this PR, it is only organization really.

The only "code change" I made was instead of keeping
```
// TibiaDataSanitizeNbspSpaceString func - replaces weird \u00A0 string to real space
func TibiaDataSanitizeNbspSpaceString(data string) string {
	ret := strings.ReplaceAll(data, "\u00A0", " ")

	return ret
}
```
I changed it to
```
// TibiaDataSanitizeNbspSpaceString func - replaces weird \u00A0 string to real space
func TibiaDataSanitizeNbspSpaceString(data string) string {
	return strings.ReplaceAll(data, "\u00A0", " ")
}
```

Let me know what you think! 