### PR TITLE
implement 404 page not found

### DIFF
--- a/src/webserver.go
+++ b/src/webserver.go
@@ -56,6 +56,11 @@ func runWebServer() {
 	// gin middleware to enable GZIP support
 	router.Use(gzip.Gzip(gzip.DefaultCompression))
 
+	// set 404 not found page
+	router.NoRoute(func(c *gin.Context) {
+		c.JSON(404, gin.H{"code": "PAGE_NOT_FOUND", "message": "Page not found"})
+	})
+
 	// disable proxy feature of gin
 	_ = router.SetTrustedProxies(nil)
 


### PR DESCRIPTION
Instead of failing on non-existent endpoints, let's return a 404 instead.