### PR TITLE
Switching to http status codes

### DIFF
--- a/src/webserver.go
+++ b/src/webserver.go
@@ -60,7 +60,7 @@ func runWebServer() {
 
 	// set 404 not found page
 	router.NoRoute(func(c *gin.Context) {
-		c.JSON(404, gin.H{"code": "PAGE_NOT_FOUND", "message": "Page not found"})
+		c.JSON(http.StatusNotFound, gin.H{"code": "PAGE_NOT_FOUND", "message": "Page not found"})
 	})
 
 	// disable proxy feature of gin
@@ -68,13 +68,13 @@ func runWebServer() {
 
 	// Ping-endpoint
 	router.GET("/ping", func(c *gin.Context) {
-		c.JSON(200, gin.H{
+		c.JSON(http.StatusOK, gin.H{
 			"message": "pong",
 		})
 	})
 
 	router.GET("/health", func(c *gin.Context) {
-		c.JSON(200, gin.H{
+		c.JSON(http.StatusOK, gin.H{
 			"status": "UP",
 		})
 	})
@@ -133,7 +133,7 @@ func runWebServer() {
 
 	// container version details endpoint
 	router.GET("/versions", func(c *gin.Context) {
-		c.JSON(200, gin.H{
+		c.JSON(http.StatusOK, gin.H{
 			"release": TibiadataBuildRelease,
 			"build":   TibiadataBuildBuilder,
 			"commit":  TibiadataBuildCommit,

--- a/src/webserver_test.go
+++ b/src/webserver_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -17,56 +18,56 @@ func TestFakeToUpCodeCoverage(t *testing.T) {
 	assert := assert.New(t)
 
 	tibiaCharactersCharacterV3(c)
-	assert.Equal(200, w.Code)
+	assert.Equal(http.StatusOK, w.Code)
 
 	tibiaCreaturesOverviewV3(c)
-	assert.Equal(200, w.Code)
+	assert.Equal(http.StatusOK, w.Code)
 
 	tibiaCreaturesCreatureV3(c)
-	assert.Equal(200, w.Code)
+	assert.Equal(http.StatusOK, w.Code)
 
 	tibiaFansitesV3(c)
-	assert.Equal(200, w.Code)
+	assert.Equal(http.StatusOK, w.Code)
 
 	tibiaGuildsGuildV3(c)
-	assert.Equal(200, w.Code)
+	assert.Equal(http.StatusOK, w.Code)
 
 	tibiaGuildsOverviewV3(c)
-	assert.Equal(200, w.Code)
+	assert.Equal(http.StatusOK, w.Code)
 
 	tibiaHighscoresV3(c)
-	assert.Equal(200, w.Code)
+	assert.Equal(http.StatusOK, w.Code)
 
 	tibiaHousesHouseV3(c)
-	assert.Equal(200, w.Code)
+	assert.Equal(http.StatusOK, w.Code)
 
 	tibiaHousesOverviewV3(c)
-	assert.Equal(200, w.Code)
+	assert.Equal(http.StatusOK, w.Code)
 
 	tibiaKillstatisticsV3(c)
-	assert.Equal(200, w.Code)
+	assert.Equal(http.StatusOK, w.Code)
 
 	assert.False(false, tibiaNewslistArchiveV3())
 	assert.False(false, tibiaNewslistArchiveDaysV3())
 	assert.False(false, tibiaNewslistLatestV3())
 
 	tibiaNewslistV3(c)
-	assert.Equal(200, w.Code)
+	assert.Equal(http.StatusOK, w.Code)
 
 	tibiaNewsV3(c)
-	assert.Equal(200, w.Code)
+	assert.Equal(http.StatusOK, w.Code)
 
 	tibiaSpellsOverviewV3(c)
-	assert.Equal(200, w.Code)
+	assert.Equal(http.StatusOK, w.Code)
 
 	tibiaSpellsSpellV3(c)
-	assert.Equal(200, w.Code)
+	assert.Equal(http.StatusOK, w.Code)
 
 	tibiaWorldsOverviewV3(c)
-	assert.Equal(200, w.Code)
+	assert.Equal(http.StatusOK, w.Code)
 
 	tibiaWorldsWorldV3(c)
-	assert.Equal(200, w.Code)
+	assert.Equal(http.StatusOK, w.Code)
 
 	assert.Equal("TibiaData-API/v3 (release/unknown; build/manual; commit/-; edition/open-source; unittest.example.com)", TibiadataUserAgentGenerator(3))
 }


### PR DESCRIPTION
Switching to http package status codes instead of plain integers
- `200` to `http.StatusOK`
- `404` to `http.StatusNotFound`