### PR TITLE
Environment function logic fix

### DIFF
--- a/src/TibiaDataUtils.go
+++ b/src/TibiaDataUtils.go
@@ -159,15 +159,6 @@ func TibiaDataConvertEncodingtoUTF8(data io.Reader) io.Reader {
 	return norm.NFKC.Reader(charmap.ISO8859_1.NewDecoder().Reader(data))
 }
 
-// isEnvExist func - check if environment var is set
-func isEnvExist(key string) bool {
-	if _, ok := os.LookupEnv(key); ok {
-		return true
-	}
-
-	return false
-}
-
 // TibiaDataSanitizeEscapedString func - run unescape string on string
 func TibiaDataSanitizeEscapedString(data string) string {
 	return html.UnescapeString(data)
@@ -181,6 +172,15 @@ func TibiaDataSanitizeDoubleQuoteString(data string) string {
 // TibiaDataSanitizeNbspSpaceString func - replaces weird \u00A0 string to real space
 func TibiaDataSanitizeNbspSpaceString(data string) string {
 	return strings.ReplaceAll(data, "\u00A0", " ")
+}
+
+// isEnvExist func - check if environment var is set
+func isEnvExist(key string) bool {
+	if _, ok := os.LookupEnv(key); ok {
+		return true
+	}
+
+	return false
 }
 
 // getEnv func - read an environment or return a default value

--- a/src/TibiaDataUtils.go
+++ b/src/TibiaDataUtils.go
@@ -175,17 +175,14 @@ func TibiaDataSanitizeNbspSpaceString(data string) string {
 }
 
 // isEnvExist func - check if environment var is set
-func isEnvExist(key string) bool {
-	if _, ok := os.LookupEnv(key); ok {
-		return true
-	}
-
-	return false
+func isEnvExist(key string) (ok bool) {
+	_, ok = os.LookupEnv(key)
+	return
 }
 
 // getEnv func - read an environment or return a default value
 func getEnv(key string, defaultVal string) string {
-	if value, exists := os.LookupEnv(key); exists {
+	if value, exists := os.LookupEnv(key); exists && value != "" {
 		return value
 	}
 


### PR DESCRIPTION
Environment vars functions logic fix (originally from https://github.com/TibiaData/tibiadata-api-go/pull/86)
- `isEnvExist` and `getEnv` are being simplified and logic is being fixed

Code adjustment as in https://github.com/TibiaData/tibiadata-api-assets/pull/6