### PR TITLE
fix guild description to contain guild details

### DIFF
--- a/src/TibiaGuildsGuildV3.go
+++ b/src/TibiaGuildsGuildV3.go
@@ -131,8 +131,15 @@ func TibiaGuildsGuildV3Impl(guild string, BoxContentHTML string) GuildResponse {
 				GuildDescriptionFinished = true
 			}
 
-		} else if GuildDescriptionFinished {
+		}
+		
+		if GuildDescriptionFinished || strings.HasPrefix(line, "The guild was founded on ") {
 			// The rest of the Guild information
+
+			if strings.HasPrefix(GuildDescription, "The guild was founded on ") {
+				GuildDescription = ""
+				GuildDescriptionFinished = true
+			}
 
 			if strings.Contains(line, "The guild was founded on") {
 				// Regex to get GuildWorld and GuildFounded


### PR DESCRIPTION
- checking if `GuildDescription` starts with foundation string and if that's the case, setting description string to be empty

fix #93