### PR TITLE
moving finished bool into auction struct

### DIFF
--- a/src/TibiaHousesOverviewV3.go
+++ b/src/TibiaHousesOverviewV3.go
@@ -15,6 +15,7 @@ import (
 type HousesAuction struct {
 	AuctionBid  int    `json:"current_bid"`
 	AuctionLeft string `json:"time_left"`
+	IsFinished  bool   `json:"finished"`
 }
 
 // Child of HousesHouses
@@ -25,7 +26,6 @@ type HousesHouse struct {
 	Rent        int           `json:"rent"`
 	IsRented    bool          `json:"rented"`
 	IsAuctioned bool          `json:"auctioned"`
-	IsFinished  bool          `json:"finished"`
 	Auction     HousesAuction `json:"auction"`
 }
 
@@ -113,7 +113,7 @@ func TibiaHousesOverviewV3Impl(c *gin.Context, world string, town string, htmlDa
 					subma1b := houseOverviewAuctionedRegex.FindAllStringSubmatch(s, -1)
 					house.Auction.AuctionBid = TibiaDataStringToIntegerV3(subma1b[0][1])
 					if subma1b[0][2] == "finished" {
-						house.IsFinished = true
+						house.Auction.IsFinished = true
 					} else {
 						house.Auction.AuctionLeft = subma1b[0][3]
 					}

--- a/src/TibiaHousesOverviewV3_test.go
+++ b/src/TibiaHousesOverviewV3_test.go
@@ -46,8 +46,7 @@ func TestAnticaThaisHousesOverview(t *testing.T) {
 	assert.Equal(50000, firstHouse.Rent)
 	assert.True(firstHouse.IsRented)
 	assert.False(firstHouse.IsAuctioned)
-	assert.False(firstHouse.IsFinished)
-	assert.Equal(HousesAuction{AuctionBid: 0, AuctionLeft: ""}, firstHouse.Auction)
+	assert.Equal(HousesAuction{AuctionBid: 0, AuctionLeft: "", IsFinished: false}, firstHouse.Auction)
 
 	lastHouse := housesJson.Houses.HouseList[117]
 	assert.Equal("Upper Swamp Lane 8", lastHouse.Name)
@@ -56,8 +55,7 @@ func TestAnticaThaisHousesOverview(t *testing.T) {
 	assert.Equal(600000, lastHouse.Rent)
 	assert.True(lastHouse.IsRented)
 	assert.False(lastHouse.IsAuctioned)
-	assert.False(lastHouse.IsFinished)
-	assert.Equal(HousesAuction{AuctionBid: 0, AuctionLeft: ""}, lastHouse.Auction)
+	assert.Equal(HousesAuction{AuctionBid: 0, AuctionLeft: "", IsFinished: false}, lastHouse.Auction)
 
 	assert.Equal(14, len(housesJson.Houses.GuildhallList))
 
@@ -68,8 +66,7 @@ func TestAnticaThaisHousesOverview(t *testing.T) {
 	assert.Equal(500000, firstGuild.Rent)
 	assert.True(firstGuild.IsRented)
 	assert.False(firstGuild.IsAuctioned)
-	assert.False(firstGuild.IsFinished)
-	assert.Equal(HousesAuction{AuctionBid: 0, AuctionLeft: ""}, firstGuild.Auction)
+	assert.Equal(HousesAuction{AuctionBid: 0, AuctionLeft: "", IsFinished: false}, firstGuild.Auction)
 
 	lastGuild := housesJson.Houses.GuildhallList[13]
 	assert.Equal("Warriors' Guildhall", lastGuild.Name)
@@ -78,8 +75,7 @@ func TestAnticaThaisHousesOverview(t *testing.T) {
 	assert.Equal(5000000, lastGuild.Rent)
 	assert.True(lastGuild.IsRented)
 	assert.False(lastGuild.IsAuctioned)
-	assert.False(lastGuild.IsFinished)
-	assert.Equal(HousesAuction{AuctionBid: 0, AuctionLeft: ""}, lastGuild.Auction)
+	assert.Equal(HousesAuction{AuctionBid: 0, AuctionLeft: "", IsFinished: false}, lastGuild.Auction)
 }
 
 func TestPremiaFarmineHousesOverview(t *testing.T) {
@@ -120,8 +116,7 @@ func TestPremiaFarmineHousesOverview(t *testing.T) {
 	assert.Equal(150000, firstHouse.Rent)
 	assert.False(firstHouse.IsRented)
 	assert.True(firstHouse.IsAuctioned)
-	assert.False(firstHouse.IsFinished)
-	assert.Equal(HousesAuction{AuctionBid: 0, AuctionLeft: ""}, firstHouse.Auction)
+	assert.Equal(HousesAuction{AuctionBid: 0, AuctionLeft: "", IsFinished: false}, firstHouse.Auction)
 
 	assert.Equal(0, len(housesJson.Houses.GuildhallList))
 }
@@ -164,8 +159,7 @@ func TestPremiaEdronHousesOverview(t *testing.T) {
 	assert.Equal(150000, auctionedHouse.Rent)
 	assert.False(auctionedHouse.IsRented)
 	assert.True(auctionedHouse.IsAuctioned)
-	assert.False(auctionedHouse.IsFinished)
-	assert.Equal(HousesAuction{AuctionBid: 200000, AuctionLeft: "9 hours"}, auctionedHouse.Auction)
+	assert.Equal(HousesAuction{AuctionBid: 200000, AuctionLeft: "9 hours", IsFinished: false}, auctionedHouse.Auction)
 
 	secondAuctionedHouse := housesJson.Houses.HouseList[56]
 	assert.Equal("Cormaya 9c", secondAuctionedHouse.Name)
@@ -174,8 +168,7 @@ func TestPremiaEdronHousesOverview(t *testing.T) {
 	assert.Equal(80000, secondAuctionedHouse.Rent)
 	assert.False(secondAuctionedHouse.IsRented)
 	assert.True(secondAuctionedHouse.IsAuctioned)
-	assert.True(secondAuctionedHouse.IsFinished)
-	assert.Equal(HousesAuction{AuctionBid: 12345, AuctionLeft: ""}, secondAuctionedHouse.Auction)
+	assert.Equal(HousesAuction{AuctionBid: 12345, AuctionLeft: "", IsFinished: true}, secondAuctionedHouse.Auction)
 
 	assert.Equal(6, len(housesJson.Houses.GuildhallList))
 }


### PR DESCRIPTION
finished is an auction-related value, so should be inside auction struct instead.

adjusts #115
ref #114 