### PR TITLE
Fix " (traded)" string appearing in account characters info

### DIFF
--- a/src/TibiaCharactersCharacterV3.go
+++ b/src/TibiaCharactersCharacterV3.go
@@ -424,7 +424,7 @@ func TibiaCharactersCharacterV3Impl(BoxContentHTML string) CharacterResponse {
 					TmpMain := false
 					if strings.Contains(TmpCharacterName, "Main Character") {
 						TmpMain = true
-						Tmp := strings.Split(subma1[0][1], "<")
+						Tmp := strings.Split(TmpCharacterName, "<")
 						TmpCharacterName = strings.TrimSpace(Tmp[0])
 					}
 


### PR DESCRIPTION
This fixes " (traded)" string appearing in account characters info.

An example of this bad behavior can be currently observed for this character https://api.tibiadata.com/v3/character/Trafnar