### PR TITLE
Removing **v** in container image tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,8 +31,8 @@ jobs:
           tags: |
             type=edge
             type=ref,event=branch,enable=${{ (github.ref != 'refs/heads/main') }}
-            type=semver,pattern=v{{version}}
-            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
Removing the leading **v** in container image tag so that it's correct [semver](https://semver.org) versioning.

This means that users that are using a specific version in their docker-compose (or other) need to remove the leading **v**.

For the upcoming version _3.3_ the tag would change from `v3.3` to `3.3`, looking like this in the docker-compose file:

```yaml
image: ghcr.io/tibiadata/tibiadata-api-go:3.3
```