### PR TITLE
Fix handling of special characters in boosted boss/creature name

### DIFF
--- a/src/TibiaBoostableBossesOverviewV3.go
+++ b/src/TibiaBoostableBossesOverviewV3.go
@@ -103,7 +103,7 @@ func TibiaBoostableBossesOverviewV3Impl(BoxContentHTML string) BoostableBossesOv
 	return BoostableBossesOverviewResponse{
 		BoostableBossesContainer{
 			Boosted: OverviewBoostableBoss{
-				Name:     BoostedBossName,
+				Name:     TibiaDataSanitizeEscapedString(BoostedBossName),
 				ImageURL: BoostedBossImage,
 				Featured: true,
 			},

--- a/src/TibiaCreaturesOverviewV3.go
+++ b/src/TibiaCreaturesOverviewV3.go
@@ -106,7 +106,7 @@ func TibiaCreaturesOverviewV3Impl(BoxContentHTML string) CreaturesOverviewRespon
 	return CreaturesOverviewResponse{
 		CreaturesContainer{
 			Boosted: OverviewCreature{
-				Name:     BoostedCreatureName,
+				Name:     TibiaDataSanitizeEscapedString(BoostedCreatureName),
 				Race:     BoostedCreatureRace,
 				ImageURL: BoostedCreatureImage,
 				Featured: true,


### PR DESCRIPTION
This fixes an issue that happened when Goshnar's Cruelty was the boosted boss:
![image](https://user-images.githubusercontent.com/2766836/185807921-b3c8329b-13f8-49da-888d-a2bf59abce1a.png)
