### PR TITLE
Adjusting highscore span to support page up to 23

### DIFF
--- a/src/webserver.go
+++ b/src/webserver.go
@@ -390,8 +390,8 @@ func tibiaHighscoresV3(c *gin.Context) {
 	if page == "" {
 		page = "1"
 	}
-	if TibiaDataStringToIntegerV3(page) < 1 || TibiaDataStringToIntegerV3(page) > 21 {
-		TibiaDataAPIHandleResponse(c, http.StatusBadRequest, "TibiaHighscoresV3", gin.H{"error": "page needs to be from 1 to 20"})
+	if TibiaDataStringToIntegerV3(page) < 1 || TibiaDataStringToIntegerV3(page) > 23 {
+		TibiaDataAPIHandleResponse(c, http.StatusBadRequest, "TibiaHighscoresV3", gin.H{"error": "page needs to be from 1 to 20 (possible until 23)"})
 		return
 	}
 


### PR DESCRIPTION
Most worlds only have 20 pages, but some worlds (where many have same type of highscores), the amount of pages can be higher. Setting max to 23 instead of 21.

fix #167