### PR TITLE
replacing strings.Title with cases.Title

### DIFF
--- a/src/TibiaDataUtils.go
+++ b/src/TibiaDataUtils.go
@@ -12,7 +12,9 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/text/cases"
 	"golang.org/x/text/encoding/charmap"
+	"golang.org/x/text/language"
 	"golang.org/x/text/unicode/norm"
 )
 
@@ -77,7 +79,7 @@ func TibiaDataRemoveURLsV3(data string) string {
 
 // TibiaDataStringWorldFormatToTitleV3 func
 func TibiaDataStringWorldFormatToTitleV3(world string) string {
-	return strings.Title(strings.ToLower(world))
+	return cases.Title(language.English).String(world)
 }
 
 // TibiaDataQueryEscapeStringV3 func - encode string to be correct formatted

--- a/src/TibiaHighscoresV3.go
+++ b/src/TibiaHighscoresV3.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/TibiaData/tibiadata-api-go/src/validation"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // Child of Highscores
@@ -161,7 +163,7 @@ func TibiaHighscoresV3Impl(world string, category validation.HighscoreCategory, 
 	// Build the data-blob
 	return &HighscoresResponse{
 		Highscores{
-			World:         strings.Title(strings.ToLower(world)),
+			World:         cases.Title(language.English).String(world),
 			Category:      categoryString,
 			Vocation:      vocationName,
 			HighscoreAge:  HighscoreAge,

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/TibiaData/tibiadata-api-go/src/validation"
 	_ "github.com/mantyr/go-charset/data"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/gin-contrib/gzip"
@@ -915,8 +917,7 @@ func tibiaSpellsOverviewV3(c *gin.Context) {
 	} else {
 		// removes the last letter (s) from the string (required for spells page)
 		vocationName = strings.TrimSuffix(vocationName, "s")
-		// setting string to first upper case
-		vocationName = strings.Title(strings.ToLower(vocationName))
+		vocationName = cases.Title(language.English).String(vocationName)
 	}
 
 	tibiadataRequest := TibiaDataRequestStruct{


### PR DESCRIPTION
_strings.Title has been deprecated since Go 1.18 and an alternative has been available since Go 1.0: The rule Title uses for word boundaries does not handle Unicode punctuation properly. Use golang.org/x/text/cases instead.  (SA1019)_