### PR TITLE
extending character name max length

### DIFF
--- a/src/validation/limits.go
+++ b/src/validation/limits.go
@@ -3,7 +3,7 @@ package validation
 const (
 	MaxRunesAllowedInACharacterName     = 29 // Larggest character name length possible
 	MinRunesAllowedInACharacterName     = 2  // Smallest character name length possible
-	MaxRunesAllowedInACharacterNameWord = 14 // Larggest character name word length possible
+	MaxRunesAllowedInACharacterNameWord = 16 // Larggest character name word length possible (new names only 14, but older ones are longer)
 	MinRunesAllowedInACharacterNameWord = 2  // Smallest character name word length possible
 
 	MaxRunesAllowedInAGuildName     = 29 // Larggest guild name length possible

--- a/src/validation/validation_test.go
+++ b/src/validation/validation_test.go
@@ -75,7 +75,7 @@ func TestNameValidator(t *testing.T) {
 		ErrorCharacterNameEmpty:            "",
 		ErrorCharacterNameTooSmall:         "o",
 		ErrorCharacterNameTooBig:           "abcabcabcabcabcabcabcabcabcabc",
-		ErrorCharacterWordTooBig:           "abcabcabcabcabc hello",
+		ErrorCharacterWordTooBig:           "abcabcabcabcabcab hello",
 		ErrorCharacterNameIsOnlyWhiteSpace: "     ",
 		ErrorCharacterNameInvalid:          "12",
 	}
@@ -836,7 +836,7 @@ func TestFake(t *testing.T) {
 
 	assert.Equal(29, MaxRunesAllowedInACharacterName)
 	assert.Equal(2, MinRunesAllowedInACharacterName)
-	assert.Equal(14, MaxRunesAllowedInACharacterNameWord)
+	assert.Equal(16, MaxRunesAllowedInACharacterNameWord)
 	assert.Equal(2, MinRunesAllowedInACharacterNameWord)
 
 	assert.Equal(29, MaxRunesAllowedInAGuildName)


### PR DESCRIPTION
Older characters can have a longer length than 14.

Example char:
- Crocodilo'Dundee

fix #193