### PR TITLE
fix highscores pages bug

### DIFF
--- a/src/webserver.go
+++ b/src/webserver.go
@@ -552,10 +552,6 @@ func tibiaHighscores(c *gin.Context) {
 		TibiaDataErrorHandler(c, validation.ErrorHighscorePageInvalid, http.StatusBadRequest)
 		return
 	}
-	if TibiaDataStringToInteger(page) > 30 {
-		TibiaDataErrorHandler(c, validation.ErrorHighscorePageTooBig, http.StatusBadRequest)
-		return
-	}
 
 	tibiadataRequest := TibiaDataRequestStruct{
 		Method: resty.MethodGet,


### PR DESCRIPTION
func tibiaHighscores had a hard limit of 30 pages, this hard limit should not be there because there are times where tibia's highscore has more than 30 pages,
for example highscore of magiclevel of knights only on Antica.

fixes https://github.com/TibiaData/tibiadata-api-go/issues/209