### PR TITLE
all: reduce heap allocations

### DIFF
--- a/src/TibiaCharactersCharacter.go
+++ b/src/TibiaCharactersCharacter.go
@@ -122,7 +122,7 @@ type CharacterResponse struct {
 const Br = 0x202
 
 // TibiaCharactersCharacter func
-func TibiaCharactersCharacterImpl(BoxContentHTML string) (*CharacterResponse, error) {
+func TibiaCharactersCharacterImpl(BoxContentHTML string) (CharacterResponse, error) {
 	var (
 		// local strings used in this function
 		localDivQueryString = ".TableContentContainer tr"
@@ -144,7 +144,7 @@ func TibiaCharactersCharacterImpl(BoxContentHTML string) (*CharacterResponse, er
 	// Loading HTML data into ReaderHTML for goquery with NewReader
 	ReaderHTML, err := goquery.NewDocumentFromReader(strings.NewReader(BoxContentHTML))
 	if err != nil {
-		return nil, fmt.Errorf("TibiaCharactersCharacterImpl failed at  goquery.NewDocumentFromReader, err: %s", err)
+		return CharacterResponse{}, fmt.Errorf("TibiaCharactersCharacterImpl failed at  goquery.NewDocumentFromReader, err: %s", err)
 	}
 
 	// Running query on every .TableContainer
@@ -612,9 +612,9 @@ func TibiaCharactersCharacterImpl(BoxContentHTML string) (*CharacterResponse, er
 	// Search for errors
 	switch {
 	case characterNotFound:
-		return nil, validation.ErrorCharacterNotFound
+		return CharacterResponse{}, validation.ErrorCharacterNotFound
 	case insideError != nil:
-		return nil, insideError
+		return CharacterResponse{}, insideError
 	case reflect.DeepEqual(charData, Character{}):
 		// There are some rare cases where a character name would
 		// bug out tibia.com (tíbia, for example) and then we would't
@@ -624,12 +624,12 @@ func TibiaCharactersCharacterImpl(BoxContentHTML string) (*CharacterResponse, er
 		//
 		// Validating those names would also be a pain because of old
 		// tibian names such as Kolskägg, which for whatever reason is valid
-		return nil, validation.ErrorCharacterNotFound
+		return CharacterResponse{}, validation.ErrorCharacterNotFound
 	}
 
 	//
 	// Build the data-blob
-	return &CharacterResponse{
+	return CharacterResponse{
 		charData,
 		Information{
 			APIDetails: TibiaDataAPIDetails,

--- a/src/TibiaCreaturesCreature.go
+++ b/src/TibiaCreaturesCreature.go
@@ -52,20 +52,20 @@ var (
 	CreatureLootRegex         = regexp.MustCompile(`.*yield (.*) experience.*carry (.*)with them.`)
 )
 
-func TibiaCreaturesCreatureImpl(race string, BoxContentHTML string) (*CreatureResponse, error) {
+func TibiaCreaturesCreatureImpl(race string, BoxContentHTML string) (CreatureResponse, error) {
 	// local strings used in this function
 	var localDamageString = " damage"
 
 	// Loading HTML data into ReaderHTML for goquery with NewReader
 	ReaderHTML, err := goquery.NewDocumentFromReader(strings.NewReader(BoxContentHTML))
 	if err != nil {
-		return nil, fmt.Errorf("[error] TibiaCreaturesCreatureImp failed at goquery.NewDocumentFromReader, error: %s", err)
+		return CreatureResponse{}, fmt.Errorf("[error] TibiaCreaturesCreatureImp failed at goquery.NewDocumentFromReader, error: %s", err)
 	}
 
 	// Getting data
 	InnerTableContainerTMP1, err := ReaderHTML.Find(".BoxContent div").First().NextAll().Html()
 	if err != nil {
-		return nil, fmt.Errorf("[error] TibiaCreaturesCreatureImp failed at ReaderHTML.Find, error: %s", err)
+		return CreatureResponse{}, fmt.Errorf("[error] TibiaCreaturesCreatureImp failed at ReaderHTML.Find, error: %s", err)
 	}
 
 	// Regex to get data
@@ -162,11 +162,11 @@ func TibiaCreaturesCreatureImpl(race string, BoxContentHTML string) (*CreatureRe
 		}
 	} else {
 		log.Printf("[warning] TibiaCreaturesCreatureImpl called on invalid creature")
-		return nil, validation.ErrorCreatureNotFound
+		return CreatureResponse{}, validation.ErrorCreatureNotFound
 	}
 
 	// Build the data-blob
-	return &CreatureResponse{
+	return CreatureResponse{
 		Creature{
 			Name:             CreatureName,
 			Race:             race,

--- a/src/TibiaCreaturesOverview.go
+++ b/src/TibiaCreaturesOverview.go
@@ -35,7 +35,7 @@ var (
 	CreatureInformationRegex        = regexp.MustCompile(`.*race=(.*)"><img src="(.*)" border.*div>(.*)<\/div>`)
 )
 
-func TibiaCreaturesOverviewImpl(BoxContentHTML string) (*CreaturesOverviewResponse, error) {
+func TibiaCreaturesOverviewImpl(BoxContentHTML string) (CreaturesOverviewResponse, error) {
 	var (
 		BoostedCreatureName, BoostedCreatureRace, BoostedCreatureImage string
 	)
@@ -43,13 +43,13 @@ func TibiaCreaturesOverviewImpl(BoxContentHTML string) (*CreaturesOverviewRespon
 	// Loading HTML data into ReaderHTML for goquery with NewReader
 	ReaderHTML, err := goquery.NewDocumentFromReader(strings.NewReader(BoxContentHTML))
 	if err != nil {
-		return nil, fmt.Errorf("[error] TibiaCreaturesOverviewImpl failed at goquery.NewDocumentFromReader, err: %s", err)
+		return CreaturesOverviewResponse{}, fmt.Errorf("[error] TibiaCreaturesOverviewImpl failed at goquery.NewDocumentFromReader, err: %s", err)
 	}
 
 	// Getting data from div.InnerTableContainer and then first p
 	InnerTableContainerTMPB, err := ReaderHTML.Find(".InnerTableContainer p").First().Html()
 	if err != nil {
-		return nil, fmt.Errorf("[error] TibiaCreaturesOverviewImpl failed at ReaderHTML.Find, err: %s", err)
+		return CreaturesOverviewResponse{}, fmt.Errorf("[error] TibiaCreaturesOverviewImpl failed at ReaderHTML.Find, err: %s", err)
 	}
 
 	// Regex to get data for name and race param for boosted creature
@@ -110,11 +110,11 @@ func TibiaCreaturesOverviewImpl(BoxContentHTML string) (*CreaturesOverviewRespon
 	})
 
 	if insideError != nil {
-		return nil, insideError
+		return CreaturesOverviewResponse{}, insideError
 	}
 
 	// Build the data-blob
-	return &CreaturesOverviewResponse{
+	return CreaturesOverviewResponse{
 		CreaturesContainer{
 			Boosted: OverviewCreature{
 				Name:     TibiaDataSanitizeEscapedString(BoostedCreatureName),

--- a/src/TibiaFansites.go
+++ b/src/TibiaFansites.go
@@ -61,11 +61,11 @@ var (
 	FansiteAnchorRegex      = regexp.MustCompile(`.*src="(.*)" alt=".*`)
 )
 
-func TibiaFansitesImpl(BoxContentHTML string) (*FansitesResponse, error) {
+func TibiaFansitesImpl(BoxContentHTML string) (FansitesResponse, error) {
 	// Loading HTML data into ReaderHTML for goquery with NewReader
 	ReaderHTML, err := goquery.NewDocumentFromReader(strings.NewReader(BoxContentHTML))
 	if err != nil {
-		return nil, fmt.Errorf("[error] TibiaFansitesImpl failed at goquery.NewDocumentFromReader, err: %s", err)
+		return FansitesResponse{}, fmt.Errorf("[error] TibiaFansitesImpl failed at goquery.NewDocumentFromReader, err: %s", err)
 	}
 
 	// Creating empty PromotedFansitesData and SupportedFansitesData var
@@ -77,7 +77,7 @@ func TibiaFansitesImpl(BoxContentHTML string) (*FansitesResponse, error) {
 	for _, FansiteType := range FansiteTypes {
 		fansites, err := makeFansiteRequest(FansiteType, ReaderHTML)
 		if err != nil {
-			return nil, fmt.Errorf("[error] TibiaFansitesImpl failed at makeFansiteRequest, type: %s, err: %s", FansiteType, err)
+			return FansitesResponse{}, fmt.Errorf("[error] TibiaFansitesImpl failed at makeFansiteRequest, type: %s, err: %s", FansiteType, err)
 		}
 
 		switch FansiteType {
@@ -89,7 +89,7 @@ func TibiaFansitesImpl(BoxContentHTML string) (*FansitesResponse, error) {
 	}
 
 	// Build the data-blob
-	return &FansitesResponse{
+	return FansitesResponse{
 		Fansites{
 			PromotedFansites:  PromotedFansitesData,
 			SupportedFansites: SupportedFansitesData,

--- a/src/TibiaGuildsGuild.go
+++ b/src/TibiaGuildsGuild.go
@@ -78,7 +78,7 @@ var (
 	GuildMemberInvitesInformationRegex = regexp.MustCompile(`<td><a.*">(.*)<\/a><\/td><td>(.*)<\/td>`)
 )
 
-func TibiaGuildsGuildImpl(guild string, BoxContentHTML string) (*GuildResponse, error) {
+func TibiaGuildsGuildImpl(guild string, BoxContentHTML string) (GuildResponse, error) {
 	// Creating empty vars
 	var (
 		MembersData                                                                                                                                                    []GuildMember
@@ -92,22 +92,22 @@ func TibiaGuildsGuildImpl(guild string, BoxContentHTML string) (*GuildResponse, 
 	// Loading HTML data into ReaderHTML for goquery with NewReader
 	ReaderHTML, err := goquery.NewDocumentFromReader(strings.NewReader(BoxContentHTML))
 	if err != nil {
-		return nil, fmt.Errorf("[error] TibiaGuildsGuildImpl failed at goquery.NewDocumentFromReader, err: %s", err)
+		return GuildResponse{}, fmt.Errorf("[error] TibiaGuildsGuildImpl failed at goquery.NewDocumentFromReader, err: %s", err)
 	}
 
 	guildName, err := ReaderHTML.Find("h1").First().Html()
 	if err != nil {
-		return nil, fmt.Errorf("[error] TibiaGuildsGuildImpl failed at ReaderHTML.Find, err: %s", err)
+		return GuildResponse{}, fmt.Errorf("[error] TibiaGuildsGuildImpl failed at ReaderHTML.Find, err: %s", err)
 	}
 
 	if guildName == "" {
-		return nil, validation.ErrorGuildNotFound
+		return GuildResponse{}, validation.ErrorGuildNotFound
 	}
 
 	// Getting data from div.InnerTableContainer and then first p
 	InnerTableContainerTMPA, err := ReaderHTML.Find(".BoxContent table").Html()
 	if err != nil {
-		return nil, fmt.Errorf("[error] TibiaGuildsGuildImpl failed at InnerTableContainerTMPA ReaderHTML.Find, err: %s", err)
+		return GuildResponse{}, fmt.Errorf("[error] TibiaGuildsGuildImpl failed at InnerTableContainerTMPA ReaderHTML.Find, err: %s", err)
 	}
 
 	subma1b := GuildLogoRegex.FindAllStringSubmatch(InnerTableContainerTMPA, -1)
@@ -119,7 +119,7 @@ func TibiaGuildsGuildImpl(guild string, BoxContentHTML string) (*GuildResponse, 
 	// Getting data from div.InnerTableContainer and then first p
 	InnerTableContainerTMPB, err := ReaderHTML.Find("#GuildInformationContainer").Html()
 	if err != nil {
-		return nil, fmt.Errorf("[error] TibiaGuildsGuildImpl failed at InnerTableContainerTMPB ReaderHTML.Find, err: %s", err)
+		return GuildResponse{}, fmt.Errorf("[error] TibiaGuildsGuildImpl failed at InnerTableContainerTMPB ReaderHTML.Find, err: %s", err)
 	}
 
 	for _, line := range strings.Split(strings.TrimSuffix(InnerTableContainerTMPB, "\n"), "\n") {
@@ -253,12 +253,12 @@ func TibiaGuildsGuildImpl(guild string, BoxContentHTML string) (*GuildResponse, 
 	})
 
 	if insideError != nil {
-		return nil, insideError
+		return GuildResponse{}, insideError
 	}
 
 	//
 	// Build the data-blob
-	return &GuildResponse{
+	return GuildResponse{
 		Guild{
 			Name:               guildName,
 			World:              GuildWorld,

--- a/src/TibiaGuildsOverview.go
+++ b/src/TibiaGuildsOverview.go
@@ -28,7 +28,7 @@ type GuildsOverviewResponse struct {
 	Information Information    `json:"information"`
 }
 
-func TibiaGuildsOverviewImpl(world string, BoxContentHTML string) (*GuildsOverviewResponse, error) {
+func TibiaGuildsOverviewImpl(world string, BoxContentHTML string) (GuildsOverviewResponse, error) {
 	// Creating empty vars
 	var (
 		ActiveGuilds, FormationGuilds []OverviewGuild
@@ -38,7 +38,7 @@ func TibiaGuildsOverviewImpl(world string, BoxContentHTML string) (*GuildsOvervi
 	// Loading HTML data into ReaderHTML for goquery with NewReader
 	ReaderHTML, err := goquery.NewDocumentFromReader(strings.NewReader(BoxContentHTML))
 	if err != nil {
-		return nil, fmt.Errorf("[error] TibiaGuildsOverviewImpl failed at goquery.NewDocumentFromReader, err: %s", err)
+		return GuildsOverviewResponse{}, fmt.Errorf("[error] TibiaGuildsOverviewImpl failed at goquery.NewDocumentFromReader, err: %s", err)
 	}
 
 	// Running query over each div
@@ -87,7 +87,7 @@ func TibiaGuildsOverviewImpl(world string, BoxContentHTML string) (*GuildsOvervi
 
 	//
 	// Build the data-blob
-	return &GuildsOverviewResponse{
+	return GuildsOverviewResponse{
 		OverviewGuilds{
 			World:     world,
 			Active:    ActiveGuilds,

--- a/src/TibiaHighscores.go
+++ b/src/TibiaHighscores.go
@@ -53,11 +53,11 @@ var (
 	SixColumnRegex      = regexp.MustCompile(`<td>(.*)<\/td><td.*">(.*)<\/a><\/td><td.*">(.*)<\/td><td>(.*)<\/td><td.*>(.*)<\/td><td.*>(.*)<\/td>`)
 )
 
-func TibiaHighscoresImpl(world string, category validation.HighscoreCategory, vocationName string, currentPage int, BoxContentHTML string) (*HighscoresResponse, error) {
+func TibiaHighscoresImpl(world string, category validation.HighscoreCategory, vocationName string, currentPage int, BoxContentHTML string) (HighscoresResponse, error) {
 	// Loading HTML data into ReaderHTML for goquery with NewReader
 	ReaderHTML, err := goquery.NewDocumentFromReader(strings.NewReader(BoxContentHTML))
 	if err != nil {
-		return nil, fmt.Errorf("[error] TibiaHighscoresImpl failed at goquery.NewDocumentFromReader, err: %s", err)
+		return HighscoresResponse{}, fmt.Errorf("[error] TibiaHighscoresImpl failed at goquery.NewDocumentFromReader, err: %s", err)
 	}
 
 	// Creating empty HighscoreData var
@@ -81,7 +81,7 @@ func TibiaHighscoresImpl(world string, category validation.HighscoreCategory, vo
 	}
 
 	if currentPage > HighscoreTotalPages {
-		return nil, validation.ErrorHighscorePageTooBig
+		return HighscoresResponse{}, validation.ErrorHighscorePageTooBig
 	}
 
 	var insideError error
@@ -156,12 +156,12 @@ func TibiaHighscoresImpl(world string, category validation.HighscoreCategory, vo
 	categoryString, _ := category.String()
 
 	if insideError != nil {
-		return nil, insideError
+		return HighscoresResponse{}, insideError
 	}
 
 	//
 	// Build the data-blob
-	return &HighscoresResponse{
+	return HighscoresResponse{
 		Highscores{
 			World:         cases.Title(language.English).String(world),
 			Category:      categoryString,

--- a/src/TibiaHousesHouse.go
+++ b/src/TibiaHousesHouse.go
@@ -72,20 +72,20 @@ var (
 )
 
 // TibiaHousesHouse func
-func TibiaHousesHouseImpl(houseid int, BoxContentHTML string) (*HouseResponse, error) {
+func TibiaHousesHouseImpl(houseid int, BoxContentHTML string) (HouseResponse, error) {
 	// Creating empty vars
 	var HouseData House
 
 	// Loading HTML data into ReaderHTML for goquery with NewReader
 	ReaderHTML, err := goquery.NewDocumentFromReader(strings.NewReader(BoxContentHTML))
 	if err != nil {
-		return nil, fmt.Errorf("[error] TibiaHousesHouseImpl failed at goquery.NewDocumentFromReader, err: %s", err)
+		return HouseResponse{}, fmt.Errorf("[error] TibiaHousesHouseImpl failed at goquery.NewDocumentFromReader, err: %s", err)
 	}
 
 	// Running query over each div
 	HouseHTML, err := ReaderHTML.Find(".BoxContent table tr").First().Html()
 	if err != nil {
-		return nil, fmt.Errorf("[error] TibiaHousesHouseImpl failed at ReaderHTML.Find, err: %s", err)
+		return HouseResponse{}, fmt.Errorf("[error] TibiaHousesHouseImpl failed at ReaderHTML.Find, err: %s", err)
 	}
 
 	// Regex to get data for house
@@ -97,7 +97,7 @@ func TibiaHousesHouseImpl(houseid int, BoxContentHTML string) (*HouseResponse, e
 
 		rawHouse, err := validation.GetHouseRaw(HouseData.Houseid)
 		if err != nil {
-			return nil, err
+			return HouseResponse{}, err
 		}
 
 		HouseData.Town = rawHouse.Town
@@ -165,7 +165,7 @@ func TibiaHousesHouseImpl(houseid int, BoxContentHTML string) (*HouseResponse, e
 	}
 
 	// Build the data-blob
-	return &HouseResponse{
+	return HouseResponse{
 		HouseData,
 		Information{
 			APIDetails: TibiaDataAPIDetails,

--- a/src/TibiaHousesOverview.go
+++ b/src/TibiaHousesOverview.go
@@ -49,7 +49,7 @@ var (
 )
 
 // TibiaHousesOverview func
-func TibiaHousesOverviewImpl(c *gin.Context, world string, town string, htmlDataCollector func(TibiaDataRequestStruct) (string, error)) (*HousesOverviewResponse, error) {
+func TibiaHousesOverviewImpl(c *gin.Context, world string, town string, htmlDataCollector func(TibiaDataRequestStruct) (string, error)) (HousesOverviewResponse, error) {
 	var (
 		// Creating empty vars
 		HouseData, GuildhallData []HousesHouse
@@ -62,7 +62,7 @@ func TibiaHousesOverviewImpl(c *gin.Context, world string, town string, htmlData
 	for _, HouseType := range HouseTypes {
 		houses, err := makeHouseRequest(HouseType, world, town, htmlDataCollector)
 		if err != nil {
-			return nil, fmt.Errorf("[error] TibiaHousesOverviewImpl failed at makeHouseRequest, type: %s, err: %s", HouseType, err)
+			return HousesOverviewResponse{}, fmt.Errorf("[error] TibiaHousesOverviewImpl failed at makeHouseRequest, type: %s, err: %s", HouseType, err)
 		}
 
 		switch HouseType {
@@ -74,7 +74,7 @@ func TibiaHousesOverviewImpl(c *gin.Context, world string, town string, htmlData
 	}
 
 	// Build the data-blob
-	return &HousesOverviewResponse{
+	return HousesOverviewResponse{
 		HousesHouses{
 			World:         world,
 			Town:          town,

--- a/src/TibiaKillstatistics.go
+++ b/src/TibiaKillstatistics.go
@@ -38,11 +38,11 @@ type KillStatisticsResponse struct {
 	Information    Information    `json:"information"`
 }
 
-func TibiaKillstatisticsImpl(world string, BoxContentHTML string) (*KillStatisticsResponse, error) {
+func TibiaKillstatisticsImpl(world string, BoxContentHTML string) (KillStatisticsResponse, error) {
 	// Loading HTML data into ReaderHTML for goquery with NewReader
 	ReaderHTML, err := goquery.NewDocumentFromReader(strings.NewReader(BoxContentHTML))
 	if err != nil {
-		return nil, fmt.Errorf("[error] TibiaKillstatisticsImpl failed at goquery.NewDocumentFromReader, err: %s", err)
+		return KillStatisticsResponse{}, fmt.Errorf("[error] TibiaKillstatisticsImpl failed at goquery.NewDocumentFromReader, err: %s", err)
 	}
 
 	// Creating empty KillStatisticsData var
@@ -76,7 +76,7 @@ func TibiaKillstatisticsImpl(world string, BoxContentHTML string) (*KillStatisti
 
 	//
 	// Build the data-blob
-	return &KillStatisticsResponse{
+	return KillStatisticsResponse{
 		KillStatistics{
 			World:   world,
 			Entries: KillStatisticsData,

--- a/src/TibiaNews.go
+++ b/src/TibiaNews.go
@@ -31,7 +31,7 @@ var (
 	martelRegex = regexp.MustCompile(`<img src=\"https:\/\/static\.tibia\.com\/images\/global\/letters\/letter_martel_(.)\.gif\" ([^\/>]+..)`)
 )
 
-func TibiaNewsImpl(NewsID int, rawUrl string, BoxContentHTML string) (*NewsResponse, error) {
+func TibiaNewsImpl(NewsID int, rawUrl string, BoxContentHTML string) (NewsResponse, error) {
 	// Declaring vars for later use..
 	var (
 		NewsData    News
@@ -43,7 +43,7 @@ func TibiaNewsImpl(NewsID int, rawUrl string, BoxContentHTML string) (*NewsRespo
 	// Loading HTML data into ReaderHTML for goquery with NewReader
 	ReaderHTML, err := goquery.NewDocumentFromReader(strings.NewReader(BoxContentHTML))
 	if err != nil {
-		return nil, fmt.Errorf("[error] TibiaNewsImpl failed at goquery.NewDocumentFromReader, err: %s", err)
+		return NewsResponse{}, fmt.Errorf("[error] TibiaNewsImpl failed at goquery.NewDocumentFromReader, err: %s", err)
 	}
 
 	NewsData.ID = NewsID
@@ -82,7 +82,7 @@ func TibiaNewsImpl(NewsID int, rawUrl string, BoxContentHTML string) (*NewsRespo
 	})
 
 	if insideError != nil {
-		return nil, insideError
+		return NewsResponse{}, insideError
 	}
 
 	ReaderHTML.Find(".NewsTableContainer").EachWithBreak(func(index int, s *goquery.Selection) bool {
@@ -125,12 +125,12 @@ func TibiaNewsImpl(NewsID int, rawUrl string, BoxContentHTML string) (*NewsRespo
 	})
 
 	if insideError != nil {
-		return nil, insideError
+		return NewsResponse{}, insideError
 	}
 
 	//
 	// Build the data-blob
-	return &NewsResponse{
+	return NewsResponse{
 		NewsData,
 		Information{
 			APIDetails: TibiaDataAPIDetails,

--- a/src/TibiaNewslist.go
+++ b/src/TibiaNewslist.go
@@ -26,14 +26,14 @@ type NewsListResponse struct {
 	Information Information `json:"information"`
 }
 
-func TibiaNewslistImpl(days int, BoxContentHTML string) (*NewsListResponse, error) {
+func TibiaNewslistImpl(days int, BoxContentHTML string) (NewsListResponse, error) {
 	// Declaring vars for later use..
 	var NewsListData []NewsItem
 
 	// Loading HTML data into ReaderHTML for goquery with NewReader
 	ReaderHTML, err := goquery.NewDocumentFromReader(strings.NewReader(BoxContentHTML))
 	if err != nil {
-		return nil, fmt.Errorf("[error] TibiaNewslistImpl failed at goquery.NewDocumentFromReader, err: %s", err)
+		return NewsListResponse{}, fmt.Errorf("[error] TibiaNewslistImpl failed at goquery.NewDocumentFromReader, err: %s", err)
 	}
 
 	var insideError error
@@ -76,12 +76,12 @@ func TibiaNewslistImpl(days int, BoxContentHTML string) (*NewsListResponse, erro
 	})
 
 	if insideError != nil {
-		return nil, insideError
+		return NewsListResponse{}, insideError
 	}
 
 	//
 	// Build the data-blob
-	return &NewsListResponse{
+	return NewsListResponse{
 		NewsListData,
 		Information{
 			APIDetails: TibiaDataAPIDetails,

--- a/src/TibiaSpellsOverview.go
+++ b/src/TibiaSpellsOverview.go
@@ -37,11 +37,11 @@ type SpellsOverviewResponse struct {
 }
 
 // TibiaSpellsOverview func
-func TibiaSpellsOverviewImpl(vocationName string, BoxContentHTML string) (*SpellsOverviewResponse, error) {
+func TibiaSpellsOverviewImpl(vocationName string, BoxContentHTML string) (SpellsOverviewResponse, error) {
 	// Loading HTML data into ReaderHTML for goquery with NewReader
 	ReaderHTML, err := goquery.NewDocumentFromReader(strings.NewReader(BoxContentHTML))
 	if err != nil {
-		return nil, fmt.Errorf("[error] TibiaSpellsOverviewImpl failed at goquery.NewDocumentFromReader, err: %s", err)
+		return SpellsOverviewResponse{}, fmt.Errorf("[error] TibiaSpellsOverviewImpl failed at goquery.NewDocumentFromReader, err: %s", err)
 	}
 
 	var SpellsData []Spell
@@ -114,7 +114,7 @@ func TibiaSpellsOverviewImpl(vocationName string, BoxContentHTML string) (*Spell
 	}
 
 	// Build the data-blob
-	return &SpellsOverviewResponse{
+	return SpellsOverviewResponse{
 		Spells{
 			SpellsVocationFilter: vocationName,
 			Spells:               SpellsData,

--- a/src/TibiaSpellsSpell.go
+++ b/src/TibiaSpellsSpell.go
@@ -67,13 +67,13 @@ var (
 )
 
 // TibiaSpellsSpell func
-func TibiaSpellsSpellImpl(spell string, BoxContentHTML string) (*SpellInformationResponse, error) {
+func TibiaSpellsSpellImpl(spell string, BoxContentHTML string) (SpellInformationResponse, error) {
 	//TODO: There is currently a bug with description, it always comes back empty
 
 	// Loading HTML data into ReaderHTML for goquery with NewReader
 	ReaderHTML, err := goquery.NewDocumentFromReader(strings.NewReader(BoxContentHTML))
 	if err != nil {
-		return nil, fmt.Errorf("[error] TibiaSpellsSpellImpl failed at goquery.NewDocumentFromReader, err: %s", err)
+		return SpellInformationResponse{}, fmt.Errorf("[error] TibiaSpellsSpellImpl failed at goquery.NewDocumentFromReader, err: %s", err)
 	}
 
 	var (
@@ -261,7 +261,7 @@ func TibiaSpellsSpellImpl(spell string, BoxContentHTML string) (*SpellInformatio
 	})
 
 	if insideError != nil {
-		return nil, insideError
+		return SpellInformationResponse{}, insideError
 	}
 
 	// Getting the description
@@ -273,7 +273,7 @@ func TibiaSpellsSpellImpl(spell string, BoxContentHTML string) (*SpellInformatio
 
 	//
 	// Build the data-blob
-	return &SpellInformationResponse{
+	return SpellInformationResponse{
 		SpellData{
 			Name:                SpellName,
 			Spell:               SpellID,

--- a/src/TibiaWorldsOverview.go
+++ b/src/TibiaWorldsOverview.go
@@ -46,11 +46,11 @@ var (
 )
 
 // TibiaWorldsOverview func
-func TibiaWorldsOverviewImpl(BoxContentHTML string) (*WorldsOverviewResponse, error) {
+func TibiaWorldsOverviewImpl(BoxContentHTML string) (WorldsOverviewResponse, error) {
 	// Loading HTML data into ReaderHTML for goquery with NewReader
 	ReaderHTML, err := goquery.NewDocumentFromReader(strings.NewReader(BoxContentHTML))
 	if err != nil {
-		return nil, fmt.Errorf("[error] TibiaWorldsOverviewImpl failed at goquery.NewDocumentFromReader, err: %s", err)
+		return WorldsOverviewResponse{}, fmt.Errorf("[error] TibiaWorldsOverviewImpl failed at goquery.NewDocumentFromReader, err: %s", err)
 	}
 
 	// Creating empty vars
@@ -190,12 +190,12 @@ func TibiaWorldsOverviewImpl(BoxContentHTML string) (*WorldsOverviewResponse, er
 	})
 
 	if insideError != nil {
-		return nil, insideError
+		return WorldsOverviewResponse{}, insideError
 	}
 
 	//
 	// Build the data-blob
-	return &WorldsOverviewResponse{
+	return WorldsOverviewResponse{
 		OverviewWorlds{
 			PlayersOnline:    WorldsAllOnlinePlayers,
 			RecordPlayers:    WorldsRecordPlayers,

--- a/src/TibiaWorldsWorld.go
+++ b/src/TibiaWorldsWorld.go
@@ -50,13 +50,13 @@ var (
 )
 
 // TibiaWorldsWorld func
-func TibiaWorldsWorldImpl(world string, BoxContentHTML string) (*WorldResponse, error) {
+func TibiaWorldsWorldImpl(world string, BoxContentHTML string) (WorldResponse, error) {
 	//TODO: We need to read the world name from the response rather than pass it into this func
 
 	// Loading HTML data into ReaderHTML for goquery with NewReader
 	ReaderHTML, err := goquery.NewDocumentFromReader(strings.NewReader(BoxContentHTML))
 	if err != nil {
-		return nil, fmt.Errorf("[error] TibiaWorldsWorldImpl failed at goquery.NewDocumentFromReader, err: %s", err)
+		return WorldResponse{}, fmt.Errorf("[error] TibiaWorldsWorldImpl failed at goquery.NewDocumentFromReader, err: %s", err)
 	}
 
 	// Creating empty vars
@@ -174,7 +174,7 @@ func TibiaWorldsWorldImpl(world string, BoxContentHTML string) (*WorldResponse, 
 	})
 
 	if insideError != nil {
-		return nil, insideError
+		return WorldResponse{}, insideError
 	}
 
 	// Running query over each div
@@ -200,12 +200,12 @@ func TibiaWorldsWorldImpl(world string, BoxContentHTML string) (*WorldResponse, 
 	})
 
 	if insideError != nil {
-		return nil, insideError
+		return WorldResponse{}, insideError
 	}
 
 	//
 	// Build the data-blob
-	return &WorldResponse{
+	return WorldResponse{
 		World: World{
 			Name:                world,
 			Status:              WorldsStatus,

--- a/src/main.go
+++ b/src/main.go
@@ -9,7 +9,7 @@ import (
 
 var (
 	// application readyz endpoint value for k8s
-	isReady *atomic.Value
+	isReady atomic.Bool
 
 	// TibiaDataDefaultVoc - default vocation when not specified in request
 	TibiaDataDefaultVoc string = "all"
@@ -58,10 +58,6 @@ func init() {
 }
 
 func main() {
-	// setup of readyness endpoint code
-	isReady = &atomic.Value{}
-	isReady.Store(false)
-
 	// logging start of TibiaData
 	log.Printf("[info] TibiaData API starting..")
 

--- a/src/tibiamapping/tibiamapping.go
+++ b/src/tibiamapping/tibiamapping.go
@@ -28,7 +28,7 @@ const (
 )
 
 // Run is used to load data from the assets JSON file
-func Run(userAgent string) (*TibiaMapping, error) {
+func Run(userAgent string) (TibiaMapping, error) {
 	// Logging the start of tibiamapping
 	log.Println("[info] Tibia Mapping is running")
 
@@ -54,40 +54,40 @@ func Run(userAgent string) (*TibiaMapping, error) {
 	// Making the GET request to the data file
 	res, err := client.R().Get(tibiaAssetsDataMinJsonURL)
 	if err != nil {
-		return nil, err
+		return TibiaMapping{}, err
 	}
 
 	// Checking if the response code was OK
 	if res.StatusCode() != http.StatusOK {
-		return nil, fmt.Errorf("res status code %d", res.StatusCode())
+		return TibiaMapping{}, fmt.Errorf("res status code %d", res.StatusCode())
 	}
 
 	// Making the GET request to the sha256 file
 	sha256, err := client.R().Get(tibiaAssetsSha256SumURL)
 	if err != nil {
-		return nil, err
+		return TibiaMapping{}, err
 	}
 
 	// Checking if the response code was OK
 	if res.StatusCode() != http.StatusOK {
-		return nil, fmt.Errorf("sha256 status code %d", res.StatusCode())
+		return TibiaMapping{}, fmt.Errorf("sha256 status code %d", res.StatusCode())
 	}
 
 	// Making the GET request to the sha512 file
 	sha512, err := client.R().Get(tibiaAssetsSha512SumURL)
 	if err != nil {
-		return nil, err
+		return TibiaMapping{}, err
 	}
 
 	// Checking if the response code was OK
 	if res.StatusCode() != http.StatusOK {
-		return nil, fmt.Errorf("sha512 status code %d", res.StatusCode())
+		return TibiaMapping{}, fmt.Errorf("sha512 status code %d", res.StatusCode())
 	}
 
 	// Log that Tibia Mapping has been successfully completed
 	log.Println("[info] Tibia Mapping completed")
 
-	return &TibiaMapping{
+	return TibiaMapping{
 		RawData:   res.Body(),
 		Sha256Sum: string(sha256.Body()),
 		Sha512Sum: string(sha512.Body()),

--- a/src/validation/tibia.go
+++ b/src/validation/tibia.go
@@ -330,54 +330,54 @@ func GetHouses() ([]House, error) {
 // of what town the house is from
 // This function will return a nil house AND a nil error
 // if the specified ID doesn't exist
-func GetHouseRaw(houseID int) (*House, error) {
+func GetHouseRaw(houseID int) (House, error) {
 	// Check if the validator has been initiated
 	if !initiated {
-		return nil, ErrorValidatorNotInitiated
+		return House{}, ErrorValidatorNotInitiated
 	}
 
 	// Try to find the house
 	for _, h := range val.Houses {
 		if h.ID == houseID {
-			return &h, nil
+			return h, nil
 		}
 	}
 
-	return nil, nil
+	return House{}, nil
 }
 
 // HouseExistsRaw reports whether a house exits, independently
 // of what town the house is from
 func HouseExistsRaw(houseID int) (bool, error) {
 	house, err := GetHouseRaw(houseID)
-	return house != nil, err
+	return house != House{}, err
 }
 
 // GetHouseInTown returns a house by it's ID and town
 // This function will return a nil house AND a nil error
 // if the specified ID doesn't exist in the specified town
 // or if the specified town doesn't exist
-func GetHouseInTown(houseID int, town string) (*House, error) {
+func GetHouseInTown(houseID int, town string) (House, error) {
 	// We don't need to check if the validator has been initiated
 	// because TownExists will already check that for us
 	townExists, err := TownExists(town)
 	if err != nil {
-		return nil, err
+		return House{}, err
 	}
 
 	// Town doesn't exist
 	if !townExists {
-		return nil, nil
+		return House{}, nil
 	}
 
 	// Try to find the house
 	for _, h := range val.Houses {
 		if h.ID == houseID && strings.EqualFold(h.Town, town) {
-			return &h, nil
+			return h, nil
 		}
 	}
 
-	return nil, nil
+	return House{}, nil
 }
 
 // HouseExistsInTown reports whether a house exits in the specified town
@@ -385,7 +385,7 @@ func GetHouseInTown(houseID int, town string) (*House, error) {
 // doesn't exist in the specified town or if the specified town doesn't exist
 func HouseExistsInTown(houseID int, town string) (bool, error) {
 	house, err := GetHouseInTown(houseID, town)
-	return house != nil, err
+	return house != House{}, err
 }
 
 // GetCreatures returns a list of all existing creatures

--- a/src/validation/validation.go
+++ b/src/validation/validation.go
@@ -70,7 +70,9 @@ func Initiate(TibiaDataUserAgent string) error {
 	}
 
 	// Check if we got a nil struct
-	if tibiaMapping == nil {
+	if len(tibiaMapping.RawData) == 0 &&
+		tibiaMapping.Sha256Sum == "" &&
+		tibiaMapping.Sha512Sum == "" {
 		return errors.New("tibia mapping struct is nil")
 	}
 

--- a/src/validation/validation_test.go
+++ b/src/validation/validation_test.go
@@ -400,7 +400,7 @@ func TestValidationFuncs(t *testing.T) {
 	}
 
 	house, err := GetHouseRaw(59052)
-	if err != nil || house == nil {
+	if err != nil || house == (House{}) {
 		t.Fatalf("GetHouseRaw error with house 59052: %s", err)
 	}
 
@@ -419,7 +419,7 @@ func TestValidationFuncs(t *testing.T) {
 	}
 
 	house, err = GetHouseInTown(59054, "Ankrahmun")
-	if err != nil || house == nil {
+	if err != nil || house == (House{}) {
 		t.Fatalf("GetHouseInTown error with house 59054 in Ankrahmun: %s", err)
 	}
 

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -1277,7 +1277,7 @@ func healthz(c *gin.Context) {
 
 // readyz is a k8s readiness probe
 func readyz(c *gin.Context) {
-	if isReady == nil || !isReady.Load().(bool) {
+	if !isReady.Load() {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": http.StatusText(http.StatusServiceUnavailable)})
 		return
 	}


### PR DESCRIPTION
Most parsers were returning a pointer to a struct type, resulting in unnecessary heap allocations.

This PR changes all parsers to return the struct they build itself, instead of a pointer to them.