### PR TITLE
Bugfix: Return error when http code from tibia is 403

### DIFF
--- a/src/validation/errors.go
+++ b/src/validation/errors.go
@@ -197,6 +197,10 @@ var (
 	// ErrorMaintenanceMode will be sent if there is ongoing maintenance
 	// Code: 20005
 	ErrorMaintenanceMode = Error{errors.New("maintenance mode active")}
+
+	// ErrorRequestThrottled will be sent if the request has been throttled
+	// Code: 20005
+	ErrorRequestThrottled = Error{errors.New("request has been throttled")}
 )
 
 // Code will return the code of the error

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -1223,7 +1223,7 @@ func TibiaDataHTMLDataCollector(TibiaDataRequest TibiaDataRequestStruct) (string
 		TibiaDataRequestTraceLogger(res, err)
 	}
 
-	if err != nil {
+	if err != nil || res.StatusCode() != http.StatusOK {
 		log.Printf("[error] TibiaDataHTMLDataCollector (Status: %s, URL: %s) in resp1: %s", res.Status(), res.Request.URL, err)
 
 		switch res.StatusCode() {
@@ -1231,7 +1231,7 @@ func TibiaDataHTMLDataCollector(TibiaDataRequest TibiaDataRequestStruct) (string
 			// throttled request
 			LogMessage = "request throttled due to rate-limitation on tibia.com"
 			log.Printf("[warning] TibiaDataHTMLDataCollector: %s!", LogMessage)
-			return "", err
+			return "", validation.ErrorRequestThrottled
 
 		case http.StatusFound:
 			// Check if page is in maintenance mode


### PR DESCRIPTION
It would love to help a bit with this issue. I'm running tibiadata in my local, and did some tests to reproduce the issue. I think I know why is it failing and returning empty data. In TibiaDataHTMLDataCollector, when the request to Tibia.com is done, there are some checks on the response http code (case http.StatusForbidden:, case http.StatusFound:). But they are done inside this if clause:

    if err != nil {

This only will be true in case that there is a network error or a timeout, because this refers to an error from the point of view of Resty, the library.

When Tibia.com throttles and returns 403 forbidden, the err variable is still null, so no http code checks are done.

With this changes, instead of returning a response with empty values, a proper error response is returned:

<img width="400" alt="Screenshot 2023-12-12 at 13 56 24" src="https://github.com/TibiaData/tibiadata-api-go/assets/4276039/5af9db80-54b2-4c04-9433-3bef7d3a21a9">

