### PR TITLE
feat: add tibia_urls field into information-section

### DIFF
--- a/src/TibiaBoostableBossesOverview.go
+++ b/src/TibiaBoostableBossesOverview.go
@@ -27,7 +27,7 @@ type BoostableBossesOverviewResponse struct {
 	Information     Information              `json:"information"`
 }
 
-func TibiaBoostableBossesOverviewImpl(BoxContentHTML string) (BoostableBossesOverviewResponse, error) {
+func TibiaBoostableBossesOverviewImpl(BoxContentHTML string, url string) (BoostableBossesOverviewResponse, error) {
 	const (
 		bodyIndexer    = `<body`
 		endBodyIndexer = `</body>`
@@ -151,7 +151,7 @@ func TibiaBoostableBossesOverviewImpl(BoxContentHTML string) (BoostableBossesOve
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURL:   "https://www.tibia.com/library/?subtopic=boostablebosses",
+			TibiaURL:   []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaBoostableBossesOverview.go
+++ b/src/TibiaBoostableBossesOverview.go
@@ -151,7 +151,7 @@ func TibiaBoostableBossesOverviewImpl(BoxContentHTML string) (BoostableBossesOve
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			Link:       "https://www.tibia.com/library/?subtopic=boostablebosses",
+			TibiaURL:   "https://www.tibia.com/library/?subtopic=boostablebosses",
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaBoostableBossesOverview.go
+++ b/src/TibiaBoostableBossesOverview.go
@@ -151,6 +151,7 @@ func TibiaBoostableBossesOverviewImpl(BoxContentHTML string) (BoostableBossesOve
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
+			Link:       "https://www.tibia.com/library/?subtopic=boostablebosses",
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaBoostableBossesOverview.go
+++ b/src/TibiaBoostableBossesOverview.go
@@ -151,7 +151,7 @@ func TibiaBoostableBossesOverviewImpl(BoxContentHTML string, url string) (Boosta
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURL:   []string{url},
+			TibiaURLs:   []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaBoostableBossesOverview.go
+++ b/src/TibiaBoostableBossesOverview.go
@@ -151,7 +151,7 @@ func TibiaBoostableBossesOverviewImpl(BoxContentHTML string, url string) (Boosta
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURLs:   []string{url},
+			TibiaURLs:  []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaBoostableBossesOverview_test.go
+++ b/src/TibiaBoostableBossesOverview_test.go
@@ -20,7 +20,7 @@ func TestBoostableBossesOverview(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	boostableBossesJson, _ := TibiaBoostableBossesOverviewImpl(string(data))
+	boostableBossesJson, _ := TibiaBoostableBossesOverviewImpl(string(data), "https://www.tibia.com/library/?subtopic=boostablebosses")
 	assert := assert.New(t)
 	boosted := boostableBossesJson.BoostableBosses.Boosted
 	bosses := boostableBossesJson.BoostableBosses.BoostableBosses
@@ -109,6 +109,6 @@ func BenchmarkTibiaBoostableBossesOverviewImpl(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		bossSink, _ = TibiaBoostableBossesOverviewImpl(data)
+		bossSink, _ = TibiaBoostableBossesOverviewImpl(data, "https://www.tibia.com/library/?subtopic=boostablebosses")
 	}
 }

--- a/src/TibiaBoostableBossesOverview_test.go
+++ b/src/TibiaBoostableBossesOverview_test.go
@@ -24,7 +24,9 @@ func TestBoostableBossesOverview(t *testing.T) {
 	assert := assert.New(t)
 	boosted := boostableBossesJson.BoostableBosses.Boosted
 	bosses := boostableBossesJson.BoostableBosses.BoostableBosses
+	information := boostableBossesJson.Information
 
+	assert.Equal("https://www.tibia.com/library/?subtopic=boostablebosses", information.Link)
 	assert.Equal(95, len(bosses))
 	assert.Equal("Ragiaz", boosted.Name)
 	assert.Equal(

--- a/src/TibiaBoostableBossesOverview_test.go
+++ b/src/TibiaBoostableBossesOverview_test.go
@@ -26,7 +26,7 @@ func TestBoostableBossesOverview(t *testing.T) {
 	bosses := boostableBossesJson.BoostableBosses.BoostableBosses
 	information := boostableBossesJson.Information
 
-	assert.Equal("https://www.tibia.com/library/?subtopic=boostablebosses", information.Link)
+	assert.Equal("https://www.tibia.com/library/?subtopic=boostablebosses", information.TibiaURL)
 	assert.Equal(95, len(bosses))
 	assert.Equal("Ragiaz", boosted.Name)
 	assert.Equal(

--- a/src/TibiaBoostableBossesOverview_test.go
+++ b/src/TibiaBoostableBossesOverview_test.go
@@ -26,7 +26,7 @@ func TestBoostableBossesOverview(t *testing.T) {
 	bosses := boostableBossesJson.BoostableBosses.BoostableBosses
 	information := boostableBossesJson.Information
 
-	assert.Equal("https://www.tibia.com/library/?subtopic=boostablebosses", information.TibiaURL)
+	assert.Equal("https://www.tibia.com/library/?subtopic=boostablebosses", information.TibiaURL[0])
 	assert.Equal(95, len(bosses))
 	assert.Equal("Ragiaz", boosted.Name)
 	assert.Equal(

--- a/src/TibiaBoostableBossesOverview_test.go
+++ b/src/TibiaBoostableBossesOverview_test.go
@@ -26,7 +26,7 @@ func TestBoostableBossesOverview(t *testing.T) {
 	bosses := boostableBossesJson.BoostableBosses.BoostableBosses
 	information := boostableBossesJson.Information
 
-	assert.Equal("https://www.tibia.com/library/?subtopic=boostablebosses", information.TibiaURL[0])
+	assert.Equal("https://www.tibia.com/library/?subtopic=boostablebosses", information.TibiaURLs[0])
 	assert.Equal(95, len(bosses))
 	assert.Equal("Ragiaz", boosted.Name)
 	assert.Equal(

--- a/src/TibiaCharactersCharacter.go
+++ b/src/TibiaCharactersCharacter.go
@@ -725,6 +725,7 @@ func TibiaCharactersCharacterImpl(BoxContentHTML string) (CharacterResponse, err
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
+			Link:       "https://www.tibia.com/community/?subtopic=characters&name=" + TibiaDataQueryEscapeString(CharacterInfoData.Name),
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaCharactersCharacter.go
+++ b/src/TibiaCharactersCharacter.go
@@ -725,7 +725,7 @@ func TibiaCharactersCharacterImpl(BoxContentHTML string) (CharacterResponse, err
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			Link:       "https://www.tibia.com/community/?subtopic=characters&name=" + TibiaDataQueryEscapeString(CharacterInfoData.Name),
+			TibiaURL:       "https://www.tibia.com/community/?subtopic=characters&name=" + TibiaDataQueryEscapeString(CharacterInfoData.Name),
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaCharactersCharacter.go
+++ b/src/TibiaCharactersCharacter.go
@@ -124,7 +124,7 @@ type CharacterResponse struct {
 const Br = 0x202
 
 // TibiaCharactersCharacter func
-func TibiaCharactersCharacterImpl(BoxContentHTML string) (CharacterResponse, error) {
+func TibiaCharactersCharacterImpl(BoxContentHTML string, url string) (CharacterResponse, error) {
 	var (
 		// local strings used in this function
 		localDivQueryString = ".TableContentContainer tr"
@@ -725,7 +725,7 @@ func TibiaCharactersCharacterImpl(BoxContentHTML string) (CharacterResponse, err
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURL:       "https://www.tibia.com/community/?subtopic=characters&name=" + TibiaDataQueryEscapeString(CharacterInfoData.Name),
+			TibiaURL:   []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaCharactersCharacter.go
+++ b/src/TibiaCharactersCharacter.go
@@ -725,7 +725,7 @@ func TibiaCharactersCharacterImpl(BoxContentHTML string, url string) (CharacterR
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURL:   []string{url},
+			TibiaURLs:   []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaCharactersCharacter.go
+++ b/src/TibiaCharactersCharacter.go
@@ -725,7 +725,7 @@ func TibiaCharactersCharacterImpl(BoxContentHTML string, url string) (CharacterR
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURLs:   []string{url},
+			TibiaURLs:  []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaCharactersCharacter_test.go
+++ b/src/TibiaCharactersCharacter_test.go
@@ -33,6 +33,7 @@ func TestNumber1(t *testing.T) {
 
 	assert := assert.New(t)
 	character := characterJson.Character.CharacterInfo
+	information := characterJson.Information
 
 	assert.Equal("Darkside Rafa", character.Name)
 	assert.Nil(character.FormerNames)
@@ -54,6 +55,8 @@ func TestNumber1(t *testing.T) {
 	assert.Equal("2022-01-05T21:23:32Z", character.LastLogin)
 	assert.Equal("Premium Account", character.AccountStatus)
 	assert.Empty(character.Comment)
+
+	assert.Equal("https://www.tibia.com/community/?subtopic=characters&name=Darkside+Rafa", information.Link)
 }
 
 func TestNumber2(t *testing.T) {

--- a/src/TibiaCharactersCharacter_test.go
+++ b/src/TibiaCharactersCharacter_test.go
@@ -56,7 +56,7 @@ func TestNumber1(t *testing.T) {
 	assert.Equal("Premium Account", character.AccountStatus)
 	assert.Empty(character.Comment)
 
-	assert.Equal("https://www.tibia.com/community/?subtopic=characters&name=Darkside+Rafa", information.TibiaURL)
+	assert.Equal("https://www.tibia.com/community/?subtopic=characters&name=Darkside+Rafa", information.TibiaURL[0])
 }
 
 func TestNumber2(t *testing.T) {

--- a/src/TibiaCharactersCharacter_test.go
+++ b/src/TibiaCharactersCharacter_test.go
@@ -56,7 +56,7 @@ func TestNumber1(t *testing.T) {
 	assert.Equal("Premium Account", character.AccountStatus)
 	assert.Empty(character.Comment)
 
-	assert.Equal("https://www.tibia.com/community/?subtopic=characters&name=Darkside+Rafa", information.Link)
+	assert.Equal("https://www.tibia.com/community/?subtopic=characters&name=Darkside+Rafa", information.TibiaURL)
 }
 
 func TestNumber2(t *testing.T) {

--- a/src/TibiaCharactersCharacter_test.go
+++ b/src/TibiaCharactersCharacter_test.go
@@ -26,7 +26,7 @@ func TestNumber1(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	characterJson, err := TibiaCharactersCharacterImpl(string(data))
+	characterJson, err := TibiaCharactersCharacterImpl(string(data), "https://www.tibia.com/community/?subtopic=characters&name=Darkside+Rafa")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +71,7 @@ func TestNumber2(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	characterJson, err := TibiaCharactersCharacterImpl(string(data))
+	characterJson, err := TibiaCharactersCharacterImpl(string(data), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -137,7 +137,7 @@ func TestNumber3(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	characterJson, err := TibiaCharactersCharacterImpl(string(data))
+	characterJson, err := TibiaCharactersCharacterImpl(string(data), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -172,7 +172,7 @@ func TestNumber4(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	characterJson, err := TibiaCharactersCharacterImpl(string(data))
+	characterJson, err := TibiaCharactersCharacterImpl(string(data), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2787,7 +2787,7 @@ func TestNumber5(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	characterJson, err := TibiaCharactersCharacterImpl(string(data))
+	characterJson, err := TibiaCharactersCharacterImpl(string(data), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2841,7 +2841,7 @@ func TestNumber6(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	characterJson, err := TibiaCharactersCharacterImpl(string(data))
+	characterJson, err := TibiaCharactersCharacterImpl(string(data), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2891,7 +2891,7 @@ func TestNumber7(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	characterJson, err := TibiaCharactersCharacterImpl(string(data))
+	characterJson, err := TibiaCharactersCharacterImpl(string(data), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2916,7 +2916,7 @@ func TestNumber8(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	characterJson, err := TibiaCharactersCharacterImpl(string(data))
+	characterJson, err := TibiaCharactersCharacterImpl(string(data), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3076,7 +3076,7 @@ func TestNumber9(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	characterJson, err := TibiaCharactersCharacterImpl(string(data))
+	characterJson, err := TibiaCharactersCharacterImpl(string(data), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3178,7 +3178,7 @@ func TestNumber10(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	characterJson, err := TibiaCharactersCharacterImpl(string(data))
+	characterJson, err := TibiaCharactersCharacterImpl(string(data), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3207,7 +3207,7 @@ func TestNumber11(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	characterJson, err := TibiaCharactersCharacterImpl(string(data))
+	characterJson, err := TibiaCharactersCharacterImpl(string(data), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3288,7 +3288,7 @@ func TestNumber12(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	characterJson, err := TibiaCharactersCharacterImpl(string(data))
+	characterJson, err := TibiaCharactersCharacterImpl(string(data), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3313,7 +3313,7 @@ func TestNumber13(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	characterJson, err := TibiaCharactersCharacterImpl(string(data))
+	characterJson, err := TibiaCharactersCharacterImpl(string(data), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3404,7 +3404,7 @@ func BenchmarkNumber1(b *testing.B) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		characterJson, _ := TibiaCharactersCharacterImpl(string(data))
+		characterJson, _ := TibiaCharactersCharacterImpl(string(data), "")
 
 		assert.Equal(b, "Darkside Rafa", characterJson.Character.CharacterInfo.Name)
 	}
@@ -3425,7 +3425,7 @@ func BenchmarkNumber2(b *testing.B) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		characterJson, _ := TibiaCharactersCharacterImpl(string(data))
+		characterJson, _ := TibiaCharactersCharacterImpl(string(data), "")
 
 		assert.Equal(b, "Riley No Hands", characterJson.Character.CharacterInfo.Name)
 	}

--- a/src/TibiaCharactersCharacter_test.go
+++ b/src/TibiaCharactersCharacter_test.go
@@ -56,7 +56,7 @@ func TestNumber1(t *testing.T) {
 	assert.Equal("Premium Account", character.AccountStatus)
 	assert.Empty(character.Comment)
 
-	assert.Equal("https://www.tibia.com/community/?subtopic=characters&name=Darkside+Rafa", information.TibiaURL[0])
+	assert.Equal("https://www.tibia.com/community/?subtopic=characters&name=Darkside+Rafa", information.TibiaURLs[0])
 }
 
 func TestNumber2(t *testing.T) {

--- a/src/TibiaCreaturesCreature.go
+++ b/src/TibiaCreaturesCreature.go
@@ -192,7 +192,7 @@ func TibiaCreaturesCreatureImpl(race string, BoxContentHTML string) (CreatureRes
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			Link:       "https://www.tibia.com/library/?subtopic=creatures&race=" + race,
+			TibiaURL:       "https://www.tibia.com/library/?subtopic=creatures&race=" + race,
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaCreaturesCreature.go
+++ b/src/TibiaCreaturesCreature.go
@@ -192,7 +192,7 @@ func TibiaCreaturesCreatureImpl(race string, BoxContentHTML string) (CreatureRes
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			Link:       "https://www.tibia.com/library/?subtopic=creatures",
+			Link:       "https://www.tibia.com/library/?subtopic=creatures&race=" + TibiaDataSanitizeEscapedString(CreatureName),
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaCreaturesCreature.go
+++ b/src/TibiaCreaturesCreature.go
@@ -192,7 +192,7 @@ func TibiaCreaturesCreatureImpl(race string, BoxContentHTML string) (CreatureRes
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			Link:       "https://www.tibia.com/library/?subtopic=creatures&race=" + TibiaDataSanitizeEscapedString(CreatureName),
+			Link:       "https://www.tibia.com/library/?subtopic=creatures&race=" + race,
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaCreaturesCreature.go
+++ b/src/TibiaCreaturesCreature.go
@@ -52,7 +52,7 @@ var (
 	CreatureLootRegex         = regexp.MustCompile(`.*yield (.*) experience.*carry (.*)with them.`)
 )
 
-func TibiaCreaturesCreatureImpl(race string, BoxContentHTML string) (CreatureResponse, error) {
+func TibiaCreaturesCreatureImpl(race string, BoxContentHTML string, url string) (CreatureResponse, error) {
 	// local strings used in this function
 	localDamageString := " damage"
 
@@ -192,7 +192,7 @@ func TibiaCreaturesCreatureImpl(race string, BoxContentHTML string) (CreatureRes
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURL:       "https://www.tibia.com/library/?subtopic=creatures&race=" + race,
+			TibiaURL:   []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaCreaturesCreature.go
+++ b/src/TibiaCreaturesCreature.go
@@ -54,7 +54,7 @@ var (
 
 func TibiaCreaturesCreatureImpl(race string, BoxContentHTML string) (CreatureResponse, error) {
 	// local strings used in this function
-	var localDamageString = " damage"
+	localDamageString := " damage"
 
 	// Loading HTML data into ReaderHTML for goquery with NewReader
 	ReaderHTML, err := goquery.NewDocumentFromReader(strings.NewReader(BoxContentHTML))
@@ -79,7 +79,7 @@ func TibiaCreaturesCreatureImpl(race string, BoxContentHTML string) (CreatureRes
 		CreatureBeParalysed, CreatureBeSummoned, CreatureBeConvinced, CreatureSeeInvisible, CreatureIsLootable, CreatureIsBoosted bool
 	)
 
-	//Find boosted creature
+	// Find boosted creature
 	boostedMonsterTitle, boostedCreatureFound := ReaderHTML.Find("#Monster").First().Attr("title")
 
 	if boostedCreatureFound {
@@ -192,6 +192,7 @@ func TibiaCreaturesCreatureImpl(race string, BoxContentHTML string) (CreatureRes
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
+			Link:       "https://www.tibia.com/library/?subtopic=creatures",
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaCreaturesCreature.go
+++ b/src/TibiaCreaturesCreature.go
@@ -192,7 +192,7 @@ func TibiaCreaturesCreatureImpl(race string, BoxContentHTML string, url string) 
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURL:   []string{url},
+			TibiaURLs:   []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaCreaturesCreature.go
+++ b/src/TibiaCreaturesCreature.go
@@ -192,7 +192,7 @@ func TibiaCreaturesCreatureImpl(race string, BoxContentHTML string, url string) 
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURLs:   []string{url},
+			TibiaURLs:  []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaCreaturesCreature_test.go
+++ b/src/TibiaCreaturesCreature_test.go
@@ -20,7 +20,7 @@ func TestDemon(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	demonJson, err := TibiaCreaturesCreatureImpl("Demon", string(data))
+	demonJson, err := TibiaCreaturesCreatureImpl("Demon", string(data), "https://www.tibia.com/library/?subtopic=creatures&race=demon")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -78,7 +78,7 @@ func TestQuaraPredatorFeatured(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	quaraPredatorJson, err := TibiaCreaturesCreatureImpl("Quara Predator", string(data))
+	quaraPredatorJson, err := TibiaCreaturesCreatureImpl("Quara Predator", string(data), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -130,7 +130,7 @@ func TestCentipede(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	centipedeJson, _ := TibiaCreaturesCreatureImpl("Centipede", string(data))
+	centipedeJson, _ := TibiaCreaturesCreatureImpl("Centipede", string(data), "")
 	assert := assert.New(t)
 
 	assert.Equal("Centipedes", centipedeJson.Creature.Name)
@@ -154,7 +154,7 @@ func TestHunter(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	hunterJson, _ := TibiaCreaturesCreatureImpl("Hunter", string(data))
+	hunterJson, _ := TibiaCreaturesCreatureImpl("Hunter", string(data), "")
 	assert := assert.New(t)
 
 	assert.Equal("Hunters", hunterJson.Creature.Name)
@@ -178,7 +178,7 @@ func TestSkunk(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	skunkJson, _ := TibiaCreaturesCreatureImpl("Skunk", string(data))
+	skunkJson, _ := TibiaCreaturesCreatureImpl("Skunk", string(data), "")
 	assert := assert.New(t)
 
 	assert.Equal("Skunks", skunkJson.Creature.Name)
@@ -202,7 +202,7 @@ func TestLavaLurkers(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	lavalurkersJson, _ := TibiaCreaturesCreatureImpl("Lava Lurkers", string(data))
+	lavalurkersJson, _ := TibiaCreaturesCreatureImpl("Lava Lurkers", string(data), "")
 	assert := assert.New(t)
 
 	assert.Equal("Lava Lurkers", lavalurkersJson.Creature.Name)

--- a/src/TibiaCreaturesCreature_test.go
+++ b/src/TibiaCreaturesCreature_test.go
@@ -26,7 +26,9 @@ func TestDemon(t *testing.T) {
 	}
 
 	assert := assert.New(t)
+	information := demonJson.Information
 
+	assert.Equal("https://www.tibia.com/library/?subtopic=creatures", information.Link)
 	assert.Equal("Demons", demonJson.Creature.Name)
 	assert.Equal("Demon", demonJson.Creature.Race)
 	assert.Equal("https://static.tibia.com/images/library/demon.gif", demonJson.Creature.ImageURL)

--- a/src/TibiaCreaturesCreature_test.go
+++ b/src/TibiaCreaturesCreature_test.go
@@ -28,7 +28,7 @@ func TestDemon(t *testing.T) {
 	assert := assert.New(t)
 	information := demonJson.Information
 
-	assert.Equal("https://www.tibia.com/library/?subtopic=creatures", information.Link)
+	assert.Equal("https://www.tibia.com/library/?subtopic=creatures&race=demon", information.Link)
 	assert.Equal("Demons", demonJson.Creature.Name)
 	assert.Equal("Demon", demonJson.Creature.Race)
 	assert.Equal("https://static.tibia.com/images/library/demon.gif", demonJson.Creature.ImageURL)

--- a/src/TibiaCreaturesCreature_test.go
+++ b/src/TibiaCreaturesCreature_test.go
@@ -28,7 +28,7 @@ func TestDemon(t *testing.T) {
 	assert := assert.New(t)
 	information := demonJson.Information
 
-	assert.Equal("https://www.tibia.com/library/?subtopic=creatures&race=demon", information.Link)
+	assert.Equal("https://www.tibia.com/library/?subtopic=creatures&race=demon", information.TibiaURL)
 	assert.Equal("Demons", demonJson.Creature.Name)
 	assert.Equal("Demon", demonJson.Creature.Race)
 	assert.Equal("https://static.tibia.com/images/library/demon.gif", demonJson.Creature.ImageURL)

--- a/src/TibiaCreaturesCreature_test.go
+++ b/src/TibiaCreaturesCreature_test.go
@@ -28,7 +28,7 @@ func TestDemon(t *testing.T) {
 	assert := assert.New(t)
 	information := demonJson.Information
 
-	assert.Equal("https://www.tibia.com/library/?subtopic=creatures&race=demon", information.TibiaURL)
+	assert.Equal("https://www.tibia.com/library/?subtopic=creatures&race=demon", information.TibiaURL[0])
 	assert.Equal("Demons", demonJson.Creature.Name)
 	assert.Equal("Demon", demonJson.Creature.Race)
 	assert.Equal("https://static.tibia.com/images/library/demon.gif", demonJson.Creature.ImageURL)

--- a/src/TibiaCreaturesCreature_test.go
+++ b/src/TibiaCreaturesCreature_test.go
@@ -28,7 +28,7 @@ func TestDemon(t *testing.T) {
 	assert := assert.New(t)
 	information := demonJson.Information
 
-	assert.Equal("https://www.tibia.com/library/?subtopic=creatures&race=demon", information.TibiaURL[0])
+	assert.Equal("https://www.tibia.com/library/?subtopic=creatures&race=demon", information.TibiaURLs[0])
 	assert.Equal("Demons", demonJson.Creature.Name)
 	assert.Equal("Demon", demonJson.Creature.Race)
 	assert.Equal("https://static.tibia.com/images/library/demon.gif", demonJson.Creature.ImageURL)

--- a/src/TibiaCreaturesOverview.go
+++ b/src/TibiaCreaturesOverview.go
@@ -125,7 +125,7 @@ func TibiaCreaturesOverviewImpl(BoxContentHTML string) (CreaturesOverviewRespons
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			Link:       "https://www.tibia.com/library/?subtopic=creatures&race=" + TibiaDataSanitizeEscapedString(BoostedCreatureName),
+			Link:       "https://www.tibia.com/library/?subtopic=creatures",
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaCreaturesOverview.go
+++ b/src/TibiaCreaturesOverview.go
@@ -125,7 +125,7 @@ func TibiaCreaturesOverviewImpl(BoxContentHTML string) (CreaturesOverviewRespons
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			Link:       "https://www.tibia.com/library/?subtopic=creatures",
+			TibiaURL:       "https://www.tibia.com/library/?subtopic=creatures",
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaCreaturesOverview.go
+++ b/src/TibiaCreaturesOverview.go
@@ -35,7 +35,7 @@ var (
 	CreatureInformationRegex        = regexp.MustCompile(`.*race=(.*)"><img src="(.*)" border.*div>(.*)<\/div>`)
 )
 
-func TibiaCreaturesOverviewImpl(BoxContentHTML string) (CreaturesOverviewResponse, error) {
+func TibiaCreaturesOverviewImpl(BoxContentHTML string, url string) (CreaturesOverviewResponse, error) {
 	var BoostedCreatureName, BoostedCreatureRace, BoostedCreatureImage string
 
 	// Loading HTML data into ReaderHTML for goquery with NewReader
@@ -125,7 +125,7 @@ func TibiaCreaturesOverviewImpl(BoxContentHTML string) (CreaturesOverviewRespons
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURL:       "https://www.tibia.com/library/?subtopic=creatures",
+			TibiaURL:   []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaCreaturesOverview.go
+++ b/src/TibiaCreaturesOverview.go
@@ -36,9 +36,7 @@ var (
 )
 
 func TibiaCreaturesOverviewImpl(BoxContentHTML string) (CreaturesOverviewResponse, error) {
-	var (
-		BoostedCreatureName, BoostedCreatureRace, BoostedCreatureImage string
-	)
+	var BoostedCreatureName, BoostedCreatureRace, BoostedCreatureImage string
 
 	// Loading HTML data into ReaderHTML for goquery with NewReader
 	ReaderHTML, err := goquery.NewDocumentFromReader(strings.NewReader(BoxContentHTML))
@@ -127,6 +125,7 @@ func TibiaCreaturesOverviewImpl(BoxContentHTML string) (CreaturesOverviewRespons
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
+			Link:       "https://www.tibia.com/library/?subtopic=creatures&race=" + TibiaDataSanitizeEscapedString(BoostedCreatureName),
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaCreaturesOverview.go
+++ b/src/TibiaCreaturesOverview.go
@@ -125,7 +125,7 @@ func TibiaCreaturesOverviewImpl(BoxContentHTML string, url string) (CreaturesOve
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURLs:   []string{url},
+			TibiaURLs:  []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaCreaturesOverview.go
+++ b/src/TibiaCreaturesOverview.go
@@ -125,7 +125,7 @@ func TibiaCreaturesOverviewImpl(BoxContentHTML string, url string) (CreaturesOve
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURL:   []string{url},
+			TibiaURLs:   []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaCreaturesOverview_test.go
+++ b/src/TibiaCreaturesOverview_test.go
@@ -28,7 +28,7 @@ func TestOverview(t *testing.T) {
 	assert := assert.New(t)
 	information := creaturesJson.Information
 
-	assert.Equal("https://www.tibia.com/library/?subtopic=creatures", information.TibiaURL)
+	assert.Equal("https://www.tibia.com/library/?subtopic=creatures", information.TibiaURL[0])
 	assert.Equal("Minotaur Amazon", creaturesJson.Creatures.Boosted.Name)
 	assert.Equal("minotauramazon", creaturesJson.Creatures.Boosted.Race)
 	assert.Equal("https://static.tibia.com/images/global/header/monsters/minotauramazon.gif", creaturesJson.Creatures.Boosted.ImageURL)

--- a/src/TibiaCreaturesOverview_test.go
+++ b/src/TibiaCreaturesOverview_test.go
@@ -20,7 +20,7 @@ func TestOverview(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	creaturesJson, err := TibiaCreaturesOverviewImpl(string(data))
+	creaturesJson, err := TibiaCreaturesOverviewImpl(string(data), "https://www.tibia.com/library/?subtopic=creatures")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/TibiaCreaturesOverview_test.go
+++ b/src/TibiaCreaturesOverview_test.go
@@ -26,7 +26,9 @@ func TestOverview(t *testing.T) {
 	}
 
 	assert := assert.New(t)
+	information := creaturesJson.Information
 
+	assert.Equal("https://www.tibia.com/library/?subtopic=creatures&race=Minotaur+Amazon", information.Link)
 	assert.Equal("Minotaur Amazon", creaturesJson.Creatures.Boosted.Name)
 	assert.Equal("minotauramazon", creaturesJson.Creatures.Boosted.Race)
 	assert.Equal("https://static.tibia.com/images/global/header/monsters/minotauramazon.gif", creaturesJson.Creatures.Boosted.ImageURL)

--- a/src/TibiaCreaturesOverview_test.go
+++ b/src/TibiaCreaturesOverview_test.go
@@ -28,7 +28,7 @@ func TestOverview(t *testing.T) {
 	assert := assert.New(t)
 	information := creaturesJson.Information
 
-	assert.Equal("https://www.tibia.com/library/?subtopic=creatures", information.Link)
+	assert.Equal("https://www.tibia.com/library/?subtopic=creatures", information.TibiaURL)
 	assert.Equal("Minotaur Amazon", creaturesJson.Creatures.Boosted.Name)
 	assert.Equal("minotauramazon", creaturesJson.Creatures.Boosted.Race)
 	assert.Equal("https://static.tibia.com/images/global/header/monsters/minotauramazon.gif", creaturesJson.Creatures.Boosted.ImageURL)

--- a/src/TibiaCreaturesOverview_test.go
+++ b/src/TibiaCreaturesOverview_test.go
@@ -28,7 +28,7 @@ func TestOverview(t *testing.T) {
 	assert := assert.New(t)
 	information := creaturesJson.Information
 
-	assert.Equal("https://www.tibia.com/library/?subtopic=creatures&race=Minotaur+Amazon", information.Link)
+	assert.Equal("https://www.tibia.com/library/?subtopic=creatures", information.Link)
 	assert.Equal("Minotaur Amazon", creaturesJson.Creatures.Boosted.Name)
 	assert.Equal("minotauramazon", creaturesJson.Creatures.Boosted.Race)
 	assert.Equal("https://static.tibia.com/images/global/header/monsters/minotauramazon.gif", creaturesJson.Creatures.Boosted.ImageURL)

--- a/src/TibiaCreaturesOverview_test.go
+++ b/src/TibiaCreaturesOverview_test.go
@@ -28,7 +28,7 @@ func TestOverview(t *testing.T) {
 	assert := assert.New(t)
 	information := creaturesJson.Information
 
-	assert.Equal("https://www.tibia.com/library/?subtopic=creatures", information.TibiaURL[0])
+	assert.Equal("https://www.tibia.com/library/?subtopic=creatures", information.TibiaURLs[0])
 	assert.Equal("Minotaur Amazon", creaturesJson.Creatures.Boosted.Name)
 	assert.Equal("minotauramazon", creaturesJson.Creatures.Boosted.Race)
 	assert.Equal("https://static.tibia.com/images/global/header/monsters/minotauramazon.gif", creaturesJson.Creatures.Boosted.ImageURL)

--- a/src/TibiaFansites.go
+++ b/src/TibiaFansites.go
@@ -97,7 +97,7 @@ func TibiaFansitesImpl(BoxContentHTML string) (FansitesResponse, error) {
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			Link:       "https://www.tibia.com/community/?subtopic=fansites",
+			TibiaURL:       "https://www.tibia.com/community/?subtopic=fansites",
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaFansites.go
+++ b/src/TibiaFansites.go
@@ -61,7 +61,7 @@ var (
 	FansiteAnchorRegex      = regexp.MustCompile(`.*src="(.*)" alt=".*`)
 )
 
-func TibiaFansitesImpl(BoxContentHTML string) (FansitesResponse, error) {
+func TibiaFansitesImpl(BoxContentHTML string, url string) (FansitesResponse, error) {
 	// Loading HTML data into ReaderHTML for goquery with NewReader
 	ReaderHTML, err := goquery.NewDocumentFromReader(strings.NewReader(BoxContentHTML))
 	if err != nil {
@@ -97,7 +97,7 @@ func TibiaFansitesImpl(BoxContentHTML string) (FansitesResponse, error) {
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURL:       "https://www.tibia.com/community/?subtopic=fansites",
+			TibiaURL:   []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaFansites.go
+++ b/src/TibiaFansites.go
@@ -97,6 +97,7 @@ func TibiaFansitesImpl(BoxContentHTML string) (FansitesResponse, error) {
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
+			Link:       "https://www.tibia.com/community/?subtopic=fansites",
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaFansites.go
+++ b/src/TibiaFansites.go
@@ -97,7 +97,7 @@ func TibiaFansitesImpl(BoxContentHTML string, url string) (FansitesResponse, err
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURLs:   []string{url},
+			TibiaURLs:  []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaFansites.go
+++ b/src/TibiaFansites.go
@@ -97,7 +97,7 @@ func TibiaFansitesImpl(BoxContentHTML string, url string) (FansitesResponse, err
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURL:   []string{url},
+			TibiaURLs:   []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaFansites_test.go
+++ b/src/TibiaFansites_test.go
@@ -86,4 +86,7 @@ func TestFansites(t *testing.T) {
 	assert.Equal("Upload, browse, like and share pictures.", tibiaGalleryFansite.Specials[0])
 	assert.True(tibiaGalleryFansite.FansiteItem)
 	assert.Equal("https://static.tibia.com/images/community/fansiteitems/TibiaGallery.com.gif", tibiaGalleryFansite.FansiteItemURL)
+
+	information := fansitesJson.Information
+	assert.Equal("https://www.tibia.com/community/?subtopic=fansites", information.Link)
 }

--- a/src/TibiaFansites_test.go
+++ b/src/TibiaFansites_test.go
@@ -88,5 +88,5 @@ func TestFansites(t *testing.T) {
 	assert.Equal("https://static.tibia.com/images/community/fansiteitems/TibiaGallery.com.gif", tibiaGalleryFansite.FansiteItemURL)
 
 	information := fansitesJson.Information
-	assert.Equal("https://www.tibia.com/community/?subtopic=fansites", information.TibiaURL)
+	assert.Equal("https://www.tibia.com/community/?subtopic=fansites", information.TibiaURL[0])
 }

--- a/src/TibiaFansites_test.go
+++ b/src/TibiaFansites_test.go
@@ -88,5 +88,5 @@ func TestFansites(t *testing.T) {
 	assert.Equal("https://static.tibia.com/images/community/fansiteitems/TibiaGallery.com.gif", tibiaGalleryFansite.FansiteItemURL)
 
 	information := fansitesJson.Information
-	assert.Equal("https://www.tibia.com/community/?subtopic=fansites", information.Link)
+	assert.Equal("https://www.tibia.com/community/?subtopic=fansites", information.TibiaURL)
 }

--- a/src/TibiaFansites_test.go
+++ b/src/TibiaFansites_test.go
@@ -20,7 +20,7 @@ func TestFansites(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	fansitesJson, err := TibiaFansitesImpl(string(data))
+	fansitesJson, err := TibiaFansitesImpl(string(data), "https://www.tibia.com/community/?subtopic=fansites")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/TibiaFansites_test.go
+++ b/src/TibiaFansites_test.go
@@ -88,5 +88,5 @@ func TestFansites(t *testing.T) {
 	assert.Equal("https://static.tibia.com/images/community/fansiteitems/TibiaGallery.com.gif", tibiaGalleryFansite.FansiteItemURL)
 
 	information := fansitesJson.Information
-	assert.Equal("https://www.tibia.com/community/?subtopic=fansites", information.TibiaURL[0])
+	assert.Equal("https://www.tibia.com/community/?subtopic=fansites", information.TibiaURLs[0])
 }

--- a/src/TibiaGuildsGuild.go
+++ b/src/TibiaGuildsGuild.go
@@ -282,7 +282,7 @@ func TibiaGuildsGuildImpl(guild string, BoxContentHTML string) (GuildResponse, e
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			Link:       "https://www.tibia.com/community/?subtopic=guilds&page=view&GuildName=" + TibiaDataQueryEscapeString(guildName),
+			TibiaURL:       "https://www.tibia.com/community/?subtopic=guilds&page=view&GuildName=" + TibiaDataQueryEscapeString(guildName),
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaGuildsGuild.go
+++ b/src/TibiaGuildsGuild.go
@@ -78,7 +78,7 @@ var (
 	GuildMemberInvitesInformationRegex = regexp.MustCompile(`<td><a.*">(.*)<\/a><\/td><td>(.*)<\/td>`)
 )
 
-func TibiaGuildsGuildImpl(guild string, BoxContentHTML string) (GuildResponse, error) {
+func TibiaGuildsGuildImpl(guild string, BoxContentHTML string, url string) (GuildResponse, error) {
 	// Creating empty vars
 	var (
 		MembersData                                                                                                                                                    []GuildMember
@@ -282,7 +282,7 @@ func TibiaGuildsGuildImpl(guild string, BoxContentHTML string) (GuildResponse, e
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURL:       "https://www.tibia.com/community/?subtopic=guilds&page=view&GuildName=" + TibiaDataQueryEscapeString(guildName),
+			TibiaURL:   []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaGuildsGuild.go
+++ b/src/TibiaGuildsGuild.go
@@ -282,6 +282,7 @@ func TibiaGuildsGuildImpl(guild string, BoxContentHTML string) (GuildResponse, e
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
+			Link:       "https://www.tibia.com/community/?subtopic=guilds&page=view&GuildName=" + TibiaDataQueryEscapeString(guildName),
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaGuildsGuild.go
+++ b/src/TibiaGuildsGuild.go
@@ -282,7 +282,7 @@ func TibiaGuildsGuildImpl(guild string, BoxContentHTML string, url string) (Guil
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURLs:   []string{url},
+			TibiaURLs:  []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaGuildsGuild.go
+++ b/src/TibiaGuildsGuild.go
@@ -282,7 +282,7 @@ func TibiaGuildsGuildImpl(guild string, BoxContentHTML string, url string) (Guil
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURL:   []string{url},
+			TibiaURLs:   []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaGuildsGuild_test.go
+++ b/src/TibiaGuildsGuild_test.go
@@ -27,6 +27,7 @@ func TestOrderofGlory(t *testing.T) {
 
 	assert := assert.New(t)
 	guild := orderOfGloryJson.Guild
+	information := orderOfGloryJson.Information
 
 	assert.Equal("Order of Glory", guild.Name)
 	assert.Equal("Premia", guild.World)
@@ -56,6 +57,8 @@ func TestOrderofGlory(t *testing.T) {
 	assert.Equal("online", guildLeader.Status)
 
 	assert.Nil(guild.Invited)
+
+	// assert.Equal("Order of Glory")
 }
 
 func TestElysium(t *testing.T) {

--- a/src/TibiaGuildsGuild_test.go
+++ b/src/TibiaGuildsGuild_test.go
@@ -20,7 +20,7 @@ func TestOrderofGlory(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	orderOfGloryJson, err := TibiaGuildsGuildImpl("Order of Glory", string(data))
+	orderOfGloryJson, err := TibiaGuildsGuildImpl("Order of Glory", string(data), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,7 +70,7 @@ func TestElysium(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	elysiumJson, err := TibiaGuildsGuildImpl("Elysium", string(data))
+	elysiumJson, err := TibiaGuildsGuildImpl("Elysium", string(data), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -126,7 +126,7 @@ func TestMercenarys(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	mercenarysJson, err := TibiaGuildsGuildImpl("Mercenarys", string(data))
+	mercenarysJson, err := TibiaGuildsGuildImpl("Mercenarys", string(data), "https://www.tibia.com/community/?subtopic=guilds&page=view&GuildName=Mercenarys")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -165,7 +165,7 @@ func TestKotkiAntica(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	kotkianticaJson, err := TibiaGuildsGuildImpl("Kotki Antica", string(data))
+	kotkianticaJson, err := TibiaGuildsGuildImpl("Kotki Antica", string(data), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -193,7 +193,7 @@ func TestNightsWatch(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	nightswatchJson, err := TibiaGuildsGuildImpl("Nights Watch", string(data))
+	nightswatchJson, err := TibiaGuildsGuildImpl("Nights Watch", string(data), "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/TibiaGuildsGuild_test.go
+++ b/src/TibiaGuildsGuild_test.go
@@ -150,7 +150,7 @@ func TestMercenarys(t *testing.T) {
 	assert.Equal("if there are still less than four vice leaders or an insufficient amount of premium accounts in the leading ranks by then", guild.DisbandedCondition)
 
 	information := mercenarysJson.Information
-	assert.Equal("https://www.tibia.com/community/?subtopic=guilds&page=view&GuildName=Mercenarys", information.TibiaURL)
+	assert.Equal("https://www.tibia.com/community/?subtopic=guilds&page=view&GuildName=Mercenarys", information.TibiaURL[0])
 }
 
 func TestKotkiAntica(t *testing.T) {

--- a/src/TibiaGuildsGuild_test.go
+++ b/src/TibiaGuildsGuild_test.go
@@ -150,7 +150,7 @@ func TestMercenarys(t *testing.T) {
 	assert.Equal("if there are still less than four vice leaders or an insufficient amount of premium accounts in the leading ranks by then", guild.DisbandedCondition)
 
 	information := mercenarysJson.Information
-	assert.Equal("https://www.tibia.com/community/?subtopic=guilds&page=view&GuildName=Mercenarys", information.Link)
+	assert.Equal("https://www.tibia.com/community/?subtopic=guilds&page=view&GuildName=Mercenarys", information.TibiaURL)
 }
 
 func TestKotkiAntica(t *testing.T) {

--- a/src/TibiaGuildsGuild_test.go
+++ b/src/TibiaGuildsGuild_test.go
@@ -58,7 +58,7 @@ func TestOrderofGlory(t *testing.T) {
 
 	assert.Nil(guild.Invited)
 
-	// assert.Equal("Order of Glory")
+	assert.Equal("https://www.tibia.com/community/?subtopic=guilds&page=view&GuildName=Order+of+Glory", information.Link)
 }
 
 func TestElysium(t *testing.T) {

--- a/src/TibiaGuildsGuild_test.go
+++ b/src/TibiaGuildsGuild_test.go
@@ -27,7 +27,6 @@ func TestOrderofGlory(t *testing.T) {
 
 	assert := assert.New(t)
 	guild := orderOfGloryJson.Guild
-	information := orderOfGloryJson.Information
 
 	assert.Equal("Order of Glory", guild.Name)
 	assert.Equal("Premia", guild.World)
@@ -57,8 +56,6 @@ func TestOrderofGlory(t *testing.T) {
 	assert.Equal("online", guildLeader.Status)
 
 	assert.Nil(guild.Invited)
-
-	assert.Equal("https://www.tibia.com/community/?subtopic=guilds&page=view&GuildName=Order+of+Glory", information.Link)
 }
 
 func TestElysium(t *testing.T) {
@@ -151,6 +148,9 @@ func TestMercenarys(t *testing.T) {
 	assert.False(guild.InWar)
 	assert.Equal("2023-02-07", guild.DisbandedDate)
 	assert.Equal("if there are still less than four vice leaders or an insufficient amount of premium accounts in the leading ranks by then", guild.DisbandedCondition)
+
+	information := mercenarysJson.Information
+	assert.Equal("https://www.tibia.com/community/?subtopic=guilds&page=view&GuildName=Mercenarys", information.Link)
 }
 
 func TestKotkiAntica(t *testing.T) {

--- a/src/TibiaGuildsGuild_test.go
+++ b/src/TibiaGuildsGuild_test.go
@@ -150,7 +150,7 @@ func TestMercenarys(t *testing.T) {
 	assert.Equal("if there are still less than four vice leaders or an insufficient amount of premium accounts in the leading ranks by then", guild.DisbandedCondition)
 
 	information := mercenarysJson.Information
-	assert.Equal("https://www.tibia.com/community/?subtopic=guilds&page=view&GuildName=Mercenarys", information.TibiaURL[0])
+	assert.Equal("https://www.tibia.com/community/?subtopic=guilds&page=view&GuildName=Mercenarys", information.TibiaURLs[0])
 }
 
 func TestKotkiAntica(t *testing.T) {

--- a/src/TibiaGuildsOverview.go
+++ b/src/TibiaGuildsOverview.go
@@ -95,7 +95,7 @@ func TibiaGuildsOverviewImpl(world string, BoxContentHTML string) (GuildsOvervie
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			Link:       "https://www.tibia.com/community/?subtopic=guilds&world=" + world,
+			TibiaURL:       "https://www.tibia.com/community/?subtopic=guilds&world=" + world,
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaGuildsOverview.go
+++ b/src/TibiaGuildsOverview.go
@@ -28,7 +28,7 @@ type GuildsOverviewResponse struct {
 	Information Information    `json:"information"`
 }
 
-func TibiaGuildsOverviewImpl(world string, BoxContentHTML string) (GuildsOverviewResponse, error) {
+func TibiaGuildsOverviewImpl(world string, BoxContentHTML string, url string) (GuildsOverviewResponse, error) {
 	// Creating empty vars
 	var (
 		ActiveGuilds, FormationGuilds []OverviewGuild
@@ -95,7 +95,7 @@ func TibiaGuildsOverviewImpl(world string, BoxContentHTML string) (GuildsOvervie
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURL:       "https://www.tibia.com/community/?subtopic=guilds&world=" + world,
+			TibiaURL:   []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaGuildsOverview.go
+++ b/src/TibiaGuildsOverview.go
@@ -48,7 +48,6 @@ func TibiaGuildsOverviewImpl(world string, BoxContentHTML string) (GuildsOvervie
 			tableName := s.Nodes[0].FirstChild.Data
 			if strings.Contains(tableName, "Active Guilds") {
 				GuildCategory = "active"
-
 			} else if strings.Contains(tableName, "Guilds in Course of Formation") {
 				GuildCategory = "formation"
 			}
@@ -96,6 +95,7 @@ func TibiaGuildsOverviewImpl(world string, BoxContentHTML string) (GuildsOvervie
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
+			Link:       "https://www.tibia.com/community/?subtopic=guilds&world=" + world,
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaGuildsOverview.go
+++ b/src/TibiaGuildsOverview.go
@@ -95,7 +95,7 @@ func TibiaGuildsOverviewImpl(world string, BoxContentHTML string, url string) (G
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURLs:   []string{url},
+			TibiaURLs:  []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaGuildsOverview.go
+++ b/src/TibiaGuildsOverview.go
@@ -95,7 +95,7 @@ func TibiaGuildsOverviewImpl(world string, BoxContentHTML string, url string) (G
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURL:   []string{url},
+			TibiaURLs:   []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaGuildsOverview_test.go
+++ b/src/TibiaGuildsOverview_test.go
@@ -20,7 +20,7 @@ func TestPremia(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	premiaGuildsJson, err := TibiaGuildsOverviewImpl("Premia", string(data))
+	premiaGuildsJson, err := TibiaGuildsOverviewImpl("Premia", string(data), "https://www.tibia.com/community/?subtopic=guilds&world=Premia")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/TibiaGuildsOverview_test.go
+++ b/src/TibiaGuildsOverview_test.go
@@ -43,5 +43,5 @@ func TestPremia(t *testing.T) {
 	assert.Equal("https://static.tibia.com/images/community/default_logo.gif", secondGuildInFormation.LogoURL)
 	assert.Empty(secondGuildInFormation.Description)
 
-	assert.Equal("https://www.tibia.com/community/?subtopic=guilds&world=Premia", information.Link)
+	assert.Equal("https://www.tibia.com/community/?subtopic=guilds&world=Premia", information.TibiaURL)
 }

--- a/src/TibiaGuildsOverview_test.go
+++ b/src/TibiaGuildsOverview_test.go
@@ -27,6 +27,8 @@ func TestPremia(t *testing.T) {
 
 	assert := assert.New(t)
 
+	information := premiaGuildsJson.Information
+
 	assert.Equal("Premia", premiaGuildsJson.Guilds.World)
 	assert.Equal(38, len(premiaGuildsJson.Guilds.Active))
 	assert.Equal(3, len(premiaGuildsJson.Guilds.Formation))
@@ -40,4 +42,6 @@ func TestPremia(t *testing.T) {
 	assert.Equal("Konungen", secondGuildInFormation.Name)
 	assert.Equal("https://static.tibia.com/images/community/default_logo.gif", secondGuildInFormation.LogoURL)
 	assert.Empty(secondGuildInFormation.Description)
+
+	assert.Equal("https://www.tibia.com/community/?subtopic=guilds&world=Premia", information.Link)
 }

--- a/src/TibiaGuildsOverview_test.go
+++ b/src/TibiaGuildsOverview_test.go
@@ -43,5 +43,5 @@ func TestPremia(t *testing.T) {
 	assert.Equal("https://static.tibia.com/images/community/default_logo.gif", secondGuildInFormation.LogoURL)
 	assert.Empty(secondGuildInFormation.Description)
 
-	assert.Equal("https://www.tibia.com/community/?subtopic=guilds&world=Premia", information.TibiaURL)
+	assert.Equal("https://www.tibia.com/community/?subtopic=guilds&world=Premia", information.TibiaURL[0])
 }

--- a/src/TibiaGuildsOverview_test.go
+++ b/src/TibiaGuildsOverview_test.go
@@ -43,5 +43,5 @@ func TestPremia(t *testing.T) {
 	assert.Equal("https://static.tibia.com/images/community/default_logo.gif", secondGuildInFormation.LogoURL)
 	assert.Empty(secondGuildInFormation.Description)
 
-	assert.Equal("https://www.tibia.com/community/?subtopic=guilds&world=Premia", information.TibiaURL[0])
+	assert.Equal("https://www.tibia.com/community/?subtopic=guilds&world=Premia", information.TibiaURLs[0])
 }

--- a/src/TibiaHighscores.go
+++ b/src/TibiaHighscores.go
@@ -177,6 +177,7 @@ func TibiaHighscoresImpl(world string, category validation.HighscoreCategory, vo
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
+			Link:       "https://www.tibia.com/community/?subtopic=highscores&world=" + cases.Title(language.English).String(world) + "&category=" + categoryString + "&profession=" + TibiaDataQueryEscapeString(vocationName) + "&currentpage=" + string(currentPage),
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaHighscores.go
+++ b/src/TibiaHighscores.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
@@ -177,7 +178,7 @@ func TibiaHighscoresImpl(world string, category validation.HighscoreCategory, vo
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			Link:       "https://www.tibia.com/community/?subtopic=highscores&world=" + cases.Title(language.English).String(world) + "&category=" + categoryString + "&profession=" + TibiaDataQueryEscapeString(vocationName) + "&currentpage=" + string(currentPage),
+			Link:       "https://www.tibia.com/community/?subtopic=highscores&world=" + cases.Title(language.English).String(world) + "&category=" + categoryString + "&profession=" + TibiaDataQueryEscapeString(vocationName) + "&currentpage=" + strconv.Itoa(currentPage),
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaHighscores.go
+++ b/src/TibiaHighscores.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
@@ -54,7 +53,7 @@ var (
 	SixColumnRegex      = regexp.MustCompile(`<td>(.*)<\/td><td.*">(.*)<\/a><\/td><td.*">(.*)<\/td><td>(.*)<\/td><td.*>(.*)<\/td><td.*>(.*)<\/td>`)
 )
 
-func TibiaHighscoresImpl(world string, category validation.HighscoreCategory, vocationName string, currentPage int, BoxContentHTML string) (HighscoresResponse, error) {
+func TibiaHighscoresImpl(world string, category validation.HighscoreCategory, vocationName string, currentPage int, BoxContentHTML string, url string) (HighscoresResponse, error) {
 	// Loading HTML data into ReaderHTML for goquery with NewReader
 	ReaderHTML, err := goquery.NewDocumentFromReader(strings.NewReader(BoxContentHTML))
 	if err != nil {
@@ -178,7 +177,7 @@ func TibiaHighscoresImpl(world string, category validation.HighscoreCategory, vo
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURL:       "https://www.tibia.com/community/?subtopic=highscores&world=" + cases.Title(language.English).String(world) + "&category=" + categoryString + "&profession=" + TibiaDataQueryEscapeString(vocationName) + "&currentpage=" + strconv.Itoa(currentPage),
+			TibiaURL:   []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaHighscores.go
+++ b/src/TibiaHighscores.go
@@ -178,7 +178,7 @@ func TibiaHighscoresImpl(world string, category validation.HighscoreCategory, vo
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			Link:       "https://www.tibia.com/community/?subtopic=highscores&world=" + cases.Title(language.English).String(world) + "&category=" + categoryString + "&profession=" + TibiaDataQueryEscapeString(vocationName) + "&currentpage=" + strconv.Itoa(currentPage),
+			TibiaURL:       "https://www.tibia.com/community/?subtopic=highscores&world=" + cases.Title(language.English).String(world) + "&category=" + categoryString + "&profession=" + TibiaDataQueryEscapeString(vocationName) + "&currentpage=" + strconv.Itoa(currentPage),
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaHighscores.go
+++ b/src/TibiaHighscores.go
@@ -177,7 +177,7 @@ func TibiaHighscoresImpl(world string, category validation.HighscoreCategory, vo
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURL:   []string{url},
+			TibiaURLs:   []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaHighscores.go
+++ b/src/TibiaHighscores.go
@@ -177,7 +177,7 @@ func TibiaHighscoresImpl(world string, category validation.HighscoreCategory, vo
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURLs:   []string{url},
+			TibiaURLs:  []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaHighscores_test.go
+++ b/src/TibiaHighscores_test.go
@@ -21,7 +21,7 @@ func TestHighscoresAll(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	highscoresJson, err := TibiaHighscoresImpl("", validation.HighScoreExperience, "all", 1, string(data))
+	highscoresJson, err := TibiaHighscoresImpl("", validation.HighScoreExperience, "all", 1, string(data), "https://www.tibia.com/community/?subtopic=highscores&world=&category=experience&profession=all&currentpage=1")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +74,7 @@ func TestHighscoresLoyalty(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	highscoresJson, err := TibiaHighscoresImpl("Vunira", validation.HighScoreLoyaltypoints, "druids", 4, string(data))
+	highscoresJson, err := TibiaHighscoresImpl("Vunira", validation.HighScoreLoyaltypoints, "druids", 4, string(data), "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/TibiaHighscores_test.go
+++ b/src/TibiaHighscores_test.go
@@ -29,7 +29,7 @@ func TestHighscoresAll(t *testing.T) {
 	assert := assert.New(t)
 	information := highscoresJson.Information
 
-	assert.Equal("https://www.tibia.com/community/?subtopic=highscores&world=&category=experience&profession=all&currentpage=1", information.TibiaURL)
+	assert.Equal("https://www.tibia.com/community/?subtopic=highscores&world=&category=experience&profession=all&currentpage=1", information.TibiaURL[0])
 
 	assert.Empty(highscoresJson.Highscores.World)
 

--- a/src/TibiaHighscores_test.go
+++ b/src/TibiaHighscores_test.go
@@ -27,8 +27,12 @@ func TestHighscoresAll(t *testing.T) {
 	}
 
 	assert := assert.New(t)
+	information := highscoresJson.Information
+
+	assert.Equal("https://www.tibia.com/community/?subtopic=highscores&world=&category=experience&profession=all&currentpage=1", information.Link)
 
 	assert.Empty(highscoresJson.Highscores.World)
+
 	assert.Equal("experience", highscoresJson.Highscores.Category)
 	assert.Equal("all", highscoresJson.Highscores.Vocation)
 	assert.Equal(12, highscoresJson.Highscores.HighscoreAge)

--- a/src/TibiaHighscores_test.go
+++ b/src/TibiaHighscores_test.go
@@ -29,7 +29,7 @@ func TestHighscoresAll(t *testing.T) {
 	assert := assert.New(t)
 	information := highscoresJson.Information
 
-	assert.Equal("https://www.tibia.com/community/?subtopic=highscores&world=&category=experience&profession=all&currentpage=1", information.Link)
+	assert.Equal("https://www.tibia.com/community/?subtopic=highscores&world=&category=experience&profession=all&currentpage=1", information.TibiaURL)
 
 	assert.Empty(highscoresJson.Highscores.World)
 

--- a/src/TibiaHighscores_test.go
+++ b/src/TibiaHighscores_test.go
@@ -29,7 +29,7 @@ func TestHighscoresAll(t *testing.T) {
 	assert := assert.New(t)
 	information := highscoresJson.Information
 
-	assert.Equal("https://www.tibia.com/community/?subtopic=highscores&world=&category=experience&profession=all&currentpage=1", information.TibiaURL[0])
+	assert.Equal("https://www.tibia.com/community/?subtopic=highscores&world=&category=experience&profession=all&currentpage=1", information.TibiaURLs[0])
 
 	assert.Empty(highscoresJson.Highscores.World)
 

--- a/src/TibiaHousesHouse.go
+++ b/src/TibiaHousesHouse.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
@@ -73,7 +72,7 @@ var (
 )
 
 // TibiaHousesHouse func
-func TibiaHousesHouseImpl(houseid int, BoxContentHTML string) (HouseResponse, error) {
+func TibiaHousesHouseImpl(houseid int, BoxContentHTML string, url string) (HouseResponse, error) {
 	// Creating empty vars
 	var HouseData House
 
@@ -171,7 +170,7 @@ func TibiaHousesHouseImpl(houseid int, BoxContentHTML string) (HouseResponse, er
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURL:       "https://www.tibia.com/community/?subtopic=houses&page=view&world=" + HouseData.World + "&houseid=" + strconv.Itoa(HouseData.Houseid),
+			TibiaURL:   []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaHousesHouse.go
+++ b/src/TibiaHousesHouse.go
@@ -171,7 +171,7 @@ func TibiaHousesHouseImpl(houseid int, BoxContentHTML string) (HouseResponse, er
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			Link:       "https://www.tibia.com/community/?subtopic=houses&page=view&world=" + HouseData.World + "&houseid=" + strconv.Itoa(HouseData.Houseid),
+			TibiaURL:       "https://www.tibia.com/community/?subtopic=houses&page=view&world=" + HouseData.World + "&houseid=" + strconv.Itoa(HouseData.Houseid),
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaHousesHouse.go
+++ b/src/TibiaHousesHouse.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
@@ -170,6 +171,7 @@ func TibiaHousesHouseImpl(houseid int, BoxContentHTML string) (HouseResponse, er
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
+			Link:       "https://www.tibia.com/community/?subtopic=houses&page=view&world=" + HouseData.World + "&houseid=" + strconv.Itoa(HouseData.Houseid),
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaHousesHouse.go
+++ b/src/TibiaHousesHouse.go
@@ -170,7 +170,7 @@ func TibiaHousesHouseImpl(houseid int, BoxContentHTML string, url string) (House
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURL:   []string{url},
+			TibiaURLs:   []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaHousesHouse.go
+++ b/src/TibiaHousesHouse.go
@@ -170,7 +170,7 @@ func TibiaHousesHouseImpl(houseid int, BoxContentHTML string, url string) (House
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURLs:   []string{url},
+			TibiaURLs:  []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaHousesHouse_test.go
+++ b/src/TibiaHousesHouse_test.go
@@ -20,7 +20,7 @@ func TestCormaya10(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	houseJson, err := TibiaHousesHouseImpl(54025, string(data))
+	houseJson, err := TibiaHousesHouseImpl(54025, string(data), "https://www.tibia.com/community/?subtopic=houses&page=view&world=Premia&houseid=54025")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,7 +72,7 @@ func TestCormaya11(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	houseJson, err := TibiaHousesHouseImpl(54026, string(data))
+	houseJson, err := TibiaHousesHouseImpl(54026, string(data), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,7 +118,7 @@ func TestCormaya9c(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	houseJson, _ := TibiaHousesHouseImpl(54023, string(data))
+	houseJson, _ := TibiaHousesHouseImpl(54023, string(data), "")
 	assert := assert.New(t)
 
 	assert.Equal(54023, houseJson.House.Houseid)
@@ -160,7 +160,7 @@ func TestBeachHomeApartmentsFlat14(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	houseJson, err := TibiaHousesHouseImpl(10214, string(data))
+	houseJson, err := TibiaHousesHouseImpl(10214, string(data), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -206,7 +206,7 @@ func TestBeachHomeApartmentsFlat15(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	houseJson, err := TibiaHousesHouseImpl(10215, string(data))
+	houseJson, err := TibiaHousesHouseImpl(10215, string(data), "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/TibiaHousesHouse_test.go
+++ b/src/TibiaHousesHouse_test.go
@@ -28,7 +28,7 @@ func TestCormaya10(t *testing.T) {
 	assert := assert.New(t)
 	information := houseJson.Information
 
-	assert.Equal("https://www.tibia.com/community/?subtopic=houses&page=view&world=Premia&houseid=54025", information.Link)
+	assert.Equal("https://www.tibia.com/community/?subtopic=houses&page=view&world=Premia&houseid=54025", information.TibiaURL)
 
 	assert.Equal(54025, houseJson.House.Houseid)
 	assert.Equal("Premia", houseJson.House.World)

--- a/src/TibiaHousesHouse_test.go
+++ b/src/TibiaHousesHouse_test.go
@@ -26,6 +26,9 @@ func TestCormaya10(t *testing.T) {
 	}
 
 	assert := assert.New(t)
+	information := houseJson.Information
+
+	assert.Equal("https://www.tibia.com/community/?subtopic=houses&page=view&world=Premia&houseid=54025", information.Link)
 
 	assert.Equal(54025, houseJson.House.Houseid)
 	assert.Equal("Premia", houseJson.House.World)

--- a/src/TibiaHousesHouse_test.go
+++ b/src/TibiaHousesHouse_test.go
@@ -28,7 +28,7 @@ func TestCormaya10(t *testing.T) {
 	assert := assert.New(t)
 	information := houseJson.Information
 
-	assert.Equal("https://www.tibia.com/community/?subtopic=houses&page=view&world=Premia&houseid=54025", information.TibiaURL)
+	assert.Equal("https://www.tibia.com/community/?subtopic=houses&page=view&world=Premia&houseid=54025", information.TibiaURL[0])
 
 	assert.Equal(54025, houseJson.House.Houseid)
 	assert.Equal("Premia", houseJson.House.World)

--- a/src/TibiaHousesHouse_test.go
+++ b/src/TibiaHousesHouse_test.go
@@ -28,7 +28,7 @@ func TestCormaya10(t *testing.T) {
 	assert := assert.New(t)
 	information := houseJson.Information
 
-	assert.Equal("https://www.tibia.com/community/?subtopic=houses&page=view&world=Premia&houseid=54025", information.TibiaURL[0])
+	assert.Equal("https://www.tibia.com/community/?subtopic=houses&page=view&world=Premia&houseid=54025", information.TibiaURLs[0])
 
 	assert.Equal(54025, houseJson.House.Houseid)
 	assert.Equal("Premia", houseJson.House.World)

--- a/src/TibiaHousesOverview.go
+++ b/src/TibiaHousesOverview.go
@@ -83,7 +83,7 @@ func TibiaHousesOverviewImpl(c *gin.Context, world string, town string, htmlData
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			Link:       "https://www.tibia.com/community/?subtopic=houses&world=" + TibiaDataQueryEscapeString(world) + "&town=" + TibiaDataQueryEscapeString(town),
+			TibiaURL:       "https://www.tibia.com/community/?subtopic=houses&world=" + TibiaDataQueryEscapeString(world) + "&town=" + TibiaDataQueryEscapeString(town),
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaHousesOverview.go
+++ b/src/TibiaHousesOverview.go
@@ -50,10 +50,9 @@ var (
 
 // TibiaHousesOverview func
 func TibiaHousesOverviewImpl(c *gin.Context, world string, town string, htmlDataCollector func(TibiaDataRequestStruct) (string, error)) (HousesOverviewResponse, error) {
-	var (
-		// Creating empty vars
-		HouseData, GuildhallData []HousesHouse
-	)
+
+	// Creating empty vars
+	var HouseData, GuildhallData []HousesHouse
 
 	// list of different fansite types
 	HouseTypes := []string{"houses", "guildhalls"}
@@ -84,6 +83,7 @@ func TibiaHousesOverviewImpl(c *gin.Context, world string, town string, htmlData
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
+			Link:       "https://www.tibia.com/community/?subtopic=houses&world=" + TibiaDataQueryEscapeString(world) + "&town=" + TibiaDataQueryEscapeString(town),
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaHousesOverview.go
+++ b/src/TibiaHousesOverview.go
@@ -85,7 +85,7 @@ func TibiaHousesOverviewImpl(c *gin.Context, world string, town string, htmlData
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURLs:   TibiaHouseURLs,
+			TibiaURLs:  TibiaHouseURLs,
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaHousesOverview.go
+++ b/src/TibiaHousesOverview.go
@@ -85,7 +85,7 @@ func TibiaHousesOverviewImpl(c *gin.Context, world string, town string, htmlData
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURL:   TibiaHouseURLs,
+			TibiaURLs:   TibiaHouseURLs,
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaHousesOverview_test.go
+++ b/src/TibiaHousesOverview_test.go
@@ -48,6 +48,9 @@ func TestAnticaThaisHousesOverview(t *testing.T) {
 	}
 
 	assert := assert.New(t)
+	information := housesJson.Information
+
+	assert.Equal("https://www.tibia.com/community/?subtopic=houses&world=Antica&town=Thais", information.Link)
 
 	assert.Equal("Antica", housesJson.Houses.World)
 	assert.Equal("Thais", housesJson.Houses.Town)

--- a/src/TibiaHousesOverview_test.go
+++ b/src/TibiaHousesOverview_test.go
@@ -50,7 +50,9 @@ func TestAnticaThaisHousesOverview(t *testing.T) {
 	assert := assert.New(t)
 	information := housesJson.Information
 
-	assert.Equal("https://www.tibia.com/community/?subtopic=houses&world=Antica&town=Thais", information.TibiaURL)
+	assert.Equal("https://www.tibia.com/community/?subtopic=houses&world=Antica&town=Thais&type=houses", information.TibiaURL[0])
+
+	assert.Equal("https://www.tibia.com/community/?subtopic=houses&world=Antica&town=Thais&type=guildhalls", information.TibiaURL[1])
 
 	assert.Equal("Antica", housesJson.Houses.World)
 	assert.Equal("Thais", housesJson.Houses.Town)

--- a/src/TibiaHousesOverview_test.go
+++ b/src/TibiaHousesOverview_test.go
@@ -50,7 +50,7 @@ func TestAnticaThaisHousesOverview(t *testing.T) {
 	assert := assert.New(t)
 	information := housesJson.Information
 
-	assert.Equal("https://www.tibia.com/community/?subtopic=houses&world=Antica&town=Thais", information.Link)
+	assert.Equal("https://www.tibia.com/community/?subtopic=houses&world=Antica&town=Thais", information.TibiaURL)
 
 	assert.Equal("Antica", housesJson.Houses.World)
 	assert.Equal("Thais", housesJson.Houses.Town)

--- a/src/TibiaHousesOverview_test.go
+++ b/src/TibiaHousesOverview_test.go
@@ -50,9 +50,9 @@ func TestAnticaThaisHousesOverview(t *testing.T) {
 	assert := assert.New(t)
 	information := housesJson.Information
 
-	assert.Equal("https://www.tibia.com/community/?subtopic=houses&world=Antica&town=Thais&type=houses", information.TibiaURL[0])
+	assert.Equal("https://www.tibia.com/community/?subtopic=houses&world=Antica&town=Thais&type=houses", information.TibiaURLs[0])
 
-	assert.Equal("https://www.tibia.com/community/?subtopic=houses&world=Antica&town=Thais&type=guildhalls", information.TibiaURL[1])
+	assert.Equal("https://www.tibia.com/community/?subtopic=houses&world=Antica&town=Thais&type=guildhalls", information.TibiaURLs[1])
 
 	assert.Equal("Antica", housesJson.Houses.World)
 	assert.Equal("Thais", housesJson.Houses.Town)

--- a/src/TibiaKillstatistics.go
+++ b/src/TibiaKillstatistics.go
@@ -90,6 +90,7 @@ func TibiaKillstatisticsImpl(world string, BoxContentHTML string) (KillStatistic
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
+			Link:       "https://www.tibia.com/community/?subtopic=killstatistics&world=" + TibiaDataQueryEscapeString(world),
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaKillstatistics.go
+++ b/src/TibiaKillstatistics.go
@@ -90,7 +90,7 @@ func TibiaKillstatisticsImpl(world string, BoxContentHTML string) (KillStatistic
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			Link:       "https://www.tibia.com/community/?subtopic=killstatistics&world=" + TibiaDataQueryEscapeString(world),
+			TibiaURL:       "https://www.tibia.com/community/?subtopic=killstatistics&world=" + TibiaDataQueryEscapeString(world),
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaKillstatistics.go
+++ b/src/TibiaKillstatistics.go
@@ -38,7 +38,7 @@ type KillStatisticsResponse struct {
 	Information    Information    `json:"information"`
 }
 
-func TibiaKillstatisticsImpl(world string, BoxContentHTML string) (KillStatisticsResponse, error) {
+func TibiaKillstatisticsImpl(world string, BoxContentHTML string, url string) (KillStatisticsResponse, error) {
 	// Loading HTML data into ReaderHTML for goquery with NewReader
 	ReaderHTML, err := goquery.NewDocumentFromReader(strings.NewReader(BoxContentHTML))
 	if err != nil {
@@ -90,7 +90,7 @@ func TibiaKillstatisticsImpl(world string, BoxContentHTML string) (KillStatistic
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURL:       "https://www.tibia.com/community/?subtopic=killstatistics&world=" + TibiaDataQueryEscapeString(world),
+			TibiaURL:   []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaKillstatistics.go
+++ b/src/TibiaKillstatistics.go
@@ -90,7 +90,7 @@ func TibiaKillstatisticsImpl(world string, BoxContentHTML string, url string) (K
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURL:   []string{url},
+			TibiaURLs:   []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaKillstatistics.go
+++ b/src/TibiaKillstatistics.go
@@ -90,7 +90,7 @@ func TibiaKillstatisticsImpl(world string, BoxContentHTML string, url string) (K
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURLs:   []string{url},
+			TibiaURLs:  []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaKillstatistics_test.go
+++ b/src/TibiaKillstatistics_test.go
@@ -20,7 +20,7 @@ func TestAntica(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	anticaJson, err := TibiaKillstatisticsImpl("Antica", string(data))
+	anticaJson, err := TibiaKillstatisticsImpl("Antica", string(data), "https://www.tibia.com/community/?subtopic=killstatistics&world=Antica")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -28,7 +28,7 @@ func TestAntica(t *testing.T) {
 	assert := assert.New(t)
 	information := anticaJson.Information
 
-	assert.Equal("https://www.tibia.com/community/?subtopic=killstatistics&world=Antica", information.TibiaURL)
+	assert.Equal("https://www.tibia.com/community/?subtopic=killstatistics&world=Antica", information.TibiaURL[0])
 
 	assert.Equal("Antica", anticaJson.KillStatistics.World)
 	assert.Equal(1159, len(anticaJson.KillStatistics.Entries))
@@ -65,7 +65,7 @@ func BenchmarkAntica(b *testing.B) {
 	assert := assert.New(b)
 
 	for i := 0; i < b.N; i++ {
-		anticaJson, err := TibiaKillstatisticsImpl("Antica", string(data))
+		anticaJson, err := TibiaKillstatisticsImpl("Antica", string(data), "")
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/src/TibiaKillstatistics_test.go
+++ b/src/TibiaKillstatistics_test.go
@@ -28,7 +28,7 @@ func TestAntica(t *testing.T) {
 	assert := assert.New(t)
 	information := anticaJson.Information
 
-	assert.Equal("https://www.tibia.com/community/?subtopic=killstatistics&world=Antica", information.Link)
+	assert.Equal("https://www.tibia.com/community/?subtopic=killstatistics&world=Antica", information.TibiaURL)
 
 	assert.Equal("Antica", anticaJson.KillStatistics.World)
 	assert.Equal(1159, len(anticaJson.KillStatistics.Entries))

--- a/src/TibiaKillstatistics_test.go
+++ b/src/TibiaKillstatistics_test.go
@@ -26,6 +26,9 @@ func TestAntica(t *testing.T) {
 	}
 
 	assert := assert.New(t)
+	information := anticaJson.Information
+
+	assert.Equal("https://www.tibia.com/community/?subtopic=killstatistics&world=Antica", information.Link)
 
 	assert.Equal("Antica", anticaJson.KillStatistics.World)
 	assert.Equal(1159, len(anticaJson.KillStatistics.Entries))

--- a/src/TibiaKillstatistics_test.go
+++ b/src/TibiaKillstatistics_test.go
@@ -28,7 +28,7 @@ func TestAntica(t *testing.T) {
 	assert := assert.New(t)
 	information := anticaJson.Information
 
-	assert.Equal("https://www.tibia.com/community/?subtopic=killstatistics&world=Antica", information.TibiaURL[0])
+	assert.Equal("https://www.tibia.com/community/?subtopic=killstatistics&world=Antica", information.TibiaURLs[0])
 
 	assert.Equal("Antica", anticaJson.KillStatistics.World)
 	assert.Equal(1159, len(anticaJson.KillStatistics.Entries))

--- a/src/TibiaNews.go
+++ b/src/TibiaNews.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
@@ -51,7 +52,6 @@ func TibiaNewsImpl(NewsID int, rawUrl string, BoxContentHTML string) (NewsRespon
 		// getting category by image src
 		CategoryImg, _ := s.Find("img").Attr("src")
 		NewsData.Category = TibiaDataGetNewsCategory(CategoryImg)
-
 		// getting date from headline
 		tmp1 = s.Find(".NewsHeadlineDate")
 		tmp2, err = tmp1.Html()
@@ -142,6 +142,7 @@ func TibiaNewsImpl(NewsID int, rawUrl string, BoxContentHTML string) (NewsRespon
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
+			Link:       "https://www.tibia.com/news/?subtopic=newsarchive&id=" + strconv.Itoa(NewsID),
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaNews.go
+++ b/src/TibiaNews.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
@@ -142,7 +141,7 @@ func TibiaNewsImpl(NewsID int, rawUrl string, BoxContentHTML string) (NewsRespon
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURL:       "https://www.tibia.com/news/?subtopic=newsarchive&id=" + strconv.Itoa(NewsID),
+			TibiaURL:   []string{rawUrl},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaNews.go
+++ b/src/TibiaNews.go
@@ -142,7 +142,7 @@ func TibiaNewsImpl(NewsID int, rawUrl string, BoxContentHTML string) (NewsRespon
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			Link:       "https://www.tibia.com/news/?subtopic=newsarchive&id=" + strconv.Itoa(NewsID),
+			TibiaURL:       "https://www.tibia.com/news/?subtopic=newsarchive&id=" + strconv.Itoa(NewsID),
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaNews.go
+++ b/src/TibiaNews.go
@@ -16,7 +16,7 @@ type News struct {
 	Title       string `json:"title,omitempty"` // The title of the news.
 	Category    string `json:"category"`        // The category of the news.
 	Type        string `json:"type,omitempty"`  // The type of news.
-	TibiaURLs    string `json:"url"`             // The URL for the news with id.
+	TibiaURL    string `json:"url"`             // The URL for the news with id.
 	Content     string `json:"content"`         // The news in plain text.
 	ContentHTML string `json:"content_html"`    // The news in HTML format.
 }
@@ -45,7 +45,7 @@ func TibiaNewsImpl(NewsID int, rawUrl string, BoxContentHTML string) (NewsRespon
 	}
 
 	NewsData.ID = NewsID
-	NewsData.TibiaURLs = rawUrl
+	NewsData.TibiaURL = rawUrl
 
 	ReaderHTML.Find(".NewsHeadline").EachWithBreak(func(index int, s *goquery.Selection) bool {
 		// getting category by image src
@@ -141,7 +141,7 @@ func TibiaNewsImpl(NewsID int, rawUrl string, BoxContentHTML string) (NewsRespon
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURLs:   []string{rawUrl},
+			TibiaURLs:  []string{rawUrl},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaNews.go
+++ b/src/TibiaNews.go
@@ -16,7 +16,7 @@ type News struct {
 	Title       string `json:"title,omitempty"` // The title of the news.
 	Category    string `json:"category"`        // The category of the news.
 	Type        string `json:"type,omitempty"`  // The type of news.
-	TibiaURL    string `json:"url"`             // The URL for the news with id.
+	TibiaURLs    string `json:"url"`             // The URL for the news with id.
 	Content     string `json:"content"`         // The news in plain text.
 	ContentHTML string `json:"content_html"`    // The news in HTML format.
 }
@@ -45,7 +45,7 @@ func TibiaNewsImpl(NewsID int, rawUrl string, BoxContentHTML string) (NewsRespon
 	}
 
 	NewsData.ID = NewsID
-	NewsData.TibiaURL = rawUrl
+	NewsData.TibiaURLs = rawUrl
 
 	ReaderHTML.Find(".NewsHeadline").EachWithBreak(func(index int, s *goquery.Selection) bool {
 		// getting category by image src
@@ -141,7 +141,7 @@ func TibiaNewsImpl(NewsID int, rawUrl string, BoxContentHTML string) (NewsRespon
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURL:   []string{rawUrl},
+			TibiaURLs:   []string{rawUrl},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaNews_test.go
+++ b/src/TibiaNews_test.go
@@ -26,6 +26,9 @@ func TestNewsById(t *testing.T) {
 	}
 
 	assert := assert.New(t)
+	information := newsArticleJson.Information
+
+	assert.Equal("https://www.tibia.com/news/?subtopic=newsarchive&id=6529", information.Link)
 
 	assert.Equal(6529, newsArticleJson.News.ID)
 	assert.Equal("2022-01-12", newsArticleJson.News.Date)

--- a/src/TibiaNews_test.go
+++ b/src/TibiaNews_test.go
@@ -28,7 +28,7 @@ func TestNewsById(t *testing.T) {
 	assert := assert.New(t)
 	information := newsArticleJson.Information
 
-	assert.Equal("https://www.tibia.com/news/?subtopic=newsarchive&id=6529", information.Link)
+	assert.Equal("https://www.tibia.com/news/?subtopic=newsarchive&id=6529", information.TibiaURL)
 
 	assert.Equal(6529, newsArticleJson.News.ID)
 	assert.Equal("2022-01-12", newsArticleJson.News.Date)

--- a/src/TibiaNews_test.go
+++ b/src/TibiaNews_test.go
@@ -28,7 +28,7 @@ func TestNewsById(t *testing.T) {
 	assert := assert.New(t)
 	information := newsArticleJson.Information
 
-	assert.Equal("https://www.tibia.com/news/?subtopic=newsarchive&id=6529", information.TibiaURL)
+	assert.Equal("https://www.tibia.com/news/?subtopic=newsarchive&id=6529", information.TibiaURL[0])
 
 	assert.Equal(6529, newsArticleJson.News.ID)
 	assert.Equal("2022-01-12", newsArticleJson.News.Date)

--- a/src/TibiaNews_test.go
+++ b/src/TibiaNews_test.go
@@ -28,14 +28,14 @@ func TestNewsById(t *testing.T) {
 	assert := assert.New(t)
 	information := newsArticleJson.Information
 
-	assert.Equal("https://www.tibia.com/news/?subtopic=newsarchive&id=6529", information.TibiaURL[0])
+	assert.Equal("https://www.tibia.com/news/?subtopic=newsarchive&id=6529", information.TibiaURLs[0])
 
 	assert.Equal(6529, newsArticleJson.News.ID)
 	assert.Equal("2022-01-12", newsArticleJson.News.Date)
 	assert.Empty(newsArticleJson.News.Title)
 	assert.Equal("development", newsArticleJson.News.Category)
 	assert.Equal("ticker", newsArticleJson.News.Type)
-	assert.Equal("https://www.tibia.com/news/?subtopic=newsarchive&id=6529", newsArticleJson.News.TibiaURL)
+	assert.Equal("https://www.tibia.com/news/?subtopic=newsarchive&id=6529", newsArticleJson.News.TibiaURLs)
 	assert.Equal("A number of issues related to the 25 years activities have been fixed, including the following: Dragon pinatas that were stuck in the inbox have been changed into dragon pinata kits. The wind-up loco can now be taken even after defeating Lord Retro. The baby seals can now be painted even when the quest The Ice Islands is active. The weight of wallpapers and fairy lights has been increased and their market category has been changed to decoration. A number of typos and map issues have been fixed as well.", newsArticleJson.News.Content)
 	assert.Equal("A number of issues related to the 25 years activities have been fixed, including the following: Dragon pinatas that were stuck in the inbox have been changed into dragon pinata kits. The wind-up loco can now be taken even after defeating Lord Retro. The baby seals can now be painted even when the quest The Ice Islands is active. The weight of wallpapers and fairy lights has been increased and their market category has been changed to decoration. A number of typos and map issues have been fixed as well.", newsArticleJson.News.ContentHTML)
 }
@@ -64,7 +64,7 @@ func TestNews6512(t *testing.T) {
 	assert.Empty(newsArticleJson.News.Title)
 	assert.Equal("community", newsArticleJson.News.Category)
 	assert.Equal("ticker", newsArticleJson.News.Type)
-	assert.Equal("https://www.tibia.com/news/?subtopic=newsarchive&id=6512", newsArticleJson.News.TibiaURL)
+	assert.Equal("https://www.tibia.com/news/?subtopic=newsarchive&id=6512", newsArticleJson.News.TibiaURLs)
 	assert.Equal("TibiaData.com has some news to share! First of all, they invite you to participate in their Discord Server. Further, they are now present on GitHub. They are working on their v3, which is still in beta. If you are interested in such things, head on over there to see what is cooking.", newsArticleJson.News.Content)
 	assert.Equal("<a href=\"https://tibiadata.com\" target=\"_blank\" rel=\"noopener noreferrer\" rel=\"noopener\">TibiaData.com</a> has some news to share! First of all, they invite you to participate in their <a href=\"https://tibiadata.com/2021/07/join-tibiadata-on-discord/\" target=\"_blank\" rel=\"noopener noreferrer\" rel=\"noopener\">Discord Server</a>. Further, they are now present on <a href=\"https://tibiadata.com/2021/12/tibiadata-has-gone-open-source/\" target=\"_blank\" rel=\"noopener noreferrer\" rel=\"noopener\">GitHub</a>. They are working on their <a href=\"https://tibiadata.com/doc-api-v3/v3-beta/\" target=\"_blank\" rel=\"noopener noreferrer\" rel=\"noopener\">v3</a>, which is still in beta. If you are interested in such things, head on over there to see what is cooking.", newsArticleJson.News.ContentHTML)
 }
@@ -93,7 +93,7 @@ func TestNews504(t *testing.T) {
 	assert.Empty(newsArticleJson.News.Title)
 	assert.Equal("community", newsArticleJson.News.Category)
 	assert.Equal("ticker", newsArticleJson.News.Type)
-	assert.Equal("https://www.tibia.com/news/?subtopic=newsarchive&id=504", newsArticleJson.News.TibiaURL)
+	assert.Equal("https://www.tibia.com/news/?subtopic=newsarchive&id=504", newsArticleJson.News.TibiaURLs)
 	assert.Equal("A new feedback form has been released today. Help us to find out which websites and magazines are popular in your country by filling out the new questionnaire. In our current poll we are curious about your occupation.", newsArticleJson.News.Content)
 	assert.Equal("<br/>A new feedback form has been released today. Help us to find out which websites and magazines are popular in your country by filling out the new questionnaire. In our current poll we are curious about your occupation.", newsArticleJson.News.ContentHTML)
 }
@@ -122,7 +122,7 @@ func TestNews6481(t *testing.T) {
 	assert.Equal("New Mounts", newsArticleJson.News.Title)
 	assert.Equal("development", newsArticleJson.News.Category)
 	assert.Empty(newsArticleJson.News.Type)
-	assert.Equal("https://www.tibia.com/news/?subtopic=newsarchive&id=6481", newsArticleJson.News.TibiaURL)
+	assert.Equal("https://www.tibia.com/news/?subtopic=newsarchive&id=6481", newsArticleJson.News.TibiaURLs)
 	assert.Equal("New mounts have been added to the Store today!\nThe origins of the Emerald Raven, Mystic Raven, and Radiant Raven are shrouded in darkness, as no written record nor tale told by even the most knowing storytellers mentions but a trace of them. Superstition surrounds them, as some see these gigantic birds as an echo of a long forgotten past, while others believe them to herald hitherto unknown events. What is clear is that they are highly intelligent beings which make great companions if they deem somebody worthy.\n\nClick on image to enlarge.\n\nOnce bought, your character can use the mount ingame anytime, no matter if you are a free account or a Premium account.\nGet yourself a corvid companion!Your Community Managers ", newsArticleJson.News.Content)
 	assert.Equal("<p>New mounts have been added to the Store today!</p>\n<p>The origins of the <strong>Emerald Raven</strong>, <strong>Mystic Raven</strong>, and <strong>Radiant Raven</strong> are shrouded in darkness, as no written record nor tale told by even the most knowing storytellers mentions but a trace of them. Superstition surrounds them, as some see these gigantic birds as an echo of a long forgotten past, while others believe them to herald hitherto unknown events. What is clear is that they are highly intelligent beings which make great companions if they deem somebody worthy.</p>\n<figure><center><img style=\"cursor: pointer;\" src=\"https://static.tibia.com/images/news/emeraldraven_small.jpg\" onclick=\"ImageInNewWindow(&#39;https://static.tibia.com/images/news/emeraldraven.jpg&#39;)\"/></center>\n<figcaption><center><em>Click on image to enlarge.</em></center></figcaption>\n</figure>\n<p>Once bought, your character can use the mount ingame anytime, no matter if you are a free account or a Premium account.</p>\n<p>Get yourself a corvid companion!<br/>Your Community Managers</p> ", newsArticleJson.News.ContentHTML)
 }

--- a/src/TibiaNews_test.go
+++ b/src/TibiaNews_test.go
@@ -35,7 +35,7 @@ func TestNewsById(t *testing.T) {
 	assert.Empty(newsArticleJson.News.Title)
 	assert.Equal("development", newsArticleJson.News.Category)
 	assert.Equal("ticker", newsArticleJson.News.Type)
-	assert.Equal("https://www.tibia.com/news/?subtopic=newsarchive&id=6529", newsArticleJson.News.TibiaURLs)
+	assert.Equal("https://www.tibia.com/news/?subtopic=newsarchive&id=6529", newsArticleJson.News.TibiaURL)
 	assert.Equal("A number of issues related to the 25 years activities have been fixed, including the following: Dragon pinatas that were stuck in the inbox have been changed into dragon pinata kits. The wind-up loco can now be taken even after defeating Lord Retro. The baby seals can now be painted even when the quest The Ice Islands is active. The weight of wallpapers and fairy lights has been increased and their market category has been changed to decoration. A number of typos and map issues have been fixed as well.", newsArticleJson.News.Content)
 	assert.Equal("A number of issues related to the 25 years activities have been fixed, including the following: Dragon pinatas that were stuck in the inbox have been changed into dragon pinata kits. The wind-up loco can now be taken even after defeating Lord Retro. The baby seals can now be painted even when the quest The Ice Islands is active. The weight of wallpapers and fairy lights has been increased and their market category has been changed to decoration. A number of typos and map issues have been fixed as well.", newsArticleJson.News.ContentHTML)
 }
@@ -64,7 +64,7 @@ func TestNews6512(t *testing.T) {
 	assert.Empty(newsArticleJson.News.Title)
 	assert.Equal("community", newsArticleJson.News.Category)
 	assert.Equal("ticker", newsArticleJson.News.Type)
-	assert.Equal("https://www.tibia.com/news/?subtopic=newsarchive&id=6512", newsArticleJson.News.TibiaURLs)
+	assert.Equal("https://www.tibia.com/news/?subtopic=newsarchive&id=6512", newsArticleJson.News.TibiaURL)
 	assert.Equal("TibiaData.com has some news to share! First of all, they invite you to participate in their Discord Server. Further, they are now present on GitHub. They are working on their v3, which is still in beta. If you are interested in such things, head on over there to see what is cooking.", newsArticleJson.News.Content)
 	assert.Equal("<a href=\"https://tibiadata.com\" target=\"_blank\" rel=\"noopener noreferrer\" rel=\"noopener\">TibiaData.com</a> has some news to share! First of all, they invite you to participate in their <a href=\"https://tibiadata.com/2021/07/join-tibiadata-on-discord/\" target=\"_blank\" rel=\"noopener noreferrer\" rel=\"noopener\">Discord Server</a>. Further, they are now present on <a href=\"https://tibiadata.com/2021/12/tibiadata-has-gone-open-source/\" target=\"_blank\" rel=\"noopener noreferrer\" rel=\"noopener\">GitHub</a>. They are working on their <a href=\"https://tibiadata.com/doc-api-v3/v3-beta/\" target=\"_blank\" rel=\"noopener noreferrer\" rel=\"noopener\">v3</a>, which is still in beta. If you are interested in such things, head on over there to see what is cooking.", newsArticleJson.News.ContentHTML)
 }
@@ -93,7 +93,7 @@ func TestNews504(t *testing.T) {
 	assert.Empty(newsArticleJson.News.Title)
 	assert.Equal("community", newsArticleJson.News.Category)
 	assert.Equal("ticker", newsArticleJson.News.Type)
-	assert.Equal("https://www.tibia.com/news/?subtopic=newsarchive&id=504", newsArticleJson.News.TibiaURLs)
+	assert.Equal("https://www.tibia.com/news/?subtopic=newsarchive&id=504", newsArticleJson.News.TibiaURL)
 	assert.Equal("A new feedback form has been released today. Help us to find out which websites and magazines are popular in your country by filling out the new questionnaire. In our current poll we are curious about your occupation.", newsArticleJson.News.Content)
 	assert.Equal("<br/>A new feedback form has been released today. Help us to find out which websites and magazines are popular in your country by filling out the new questionnaire. In our current poll we are curious about your occupation.", newsArticleJson.News.ContentHTML)
 }
@@ -122,7 +122,7 @@ func TestNews6481(t *testing.T) {
 	assert.Equal("New Mounts", newsArticleJson.News.Title)
 	assert.Equal("development", newsArticleJson.News.Category)
 	assert.Empty(newsArticleJson.News.Type)
-	assert.Equal("https://www.tibia.com/news/?subtopic=newsarchive&id=6481", newsArticleJson.News.TibiaURLs)
+	assert.Equal("https://www.tibia.com/news/?subtopic=newsarchive&id=6481", newsArticleJson.News.TibiaURL)
 	assert.Equal("New mounts have been added to the Store today!\nThe origins of the Emerald Raven, Mystic Raven, and Radiant Raven are shrouded in darkness, as no written record nor tale told by even the most knowing storytellers mentions but a trace of them. Superstition surrounds them, as some see these gigantic birds as an echo of a long forgotten past, while others believe them to herald hitherto unknown events. What is clear is that they are highly intelligent beings which make great companions if they deem somebody worthy.\n\nClick on image to enlarge.\n\nOnce bought, your character can use the mount ingame anytime, no matter if you are a free account or a Premium account.\nGet yourself a corvid companion!Your Community Managers ", newsArticleJson.News.Content)
 	assert.Equal("<p>New mounts have been added to the Store today!</p>\n<p>The origins of the <strong>Emerald Raven</strong>, <strong>Mystic Raven</strong>, and <strong>Radiant Raven</strong> are shrouded in darkness, as no written record nor tale told by even the most knowing storytellers mentions but a trace of them. Superstition surrounds them, as some see these gigantic birds as an echo of a long forgotten past, while others believe them to herald hitherto unknown events. What is clear is that they are highly intelligent beings which make great companions if they deem somebody worthy.</p>\n<figure><center><img style=\"cursor: pointer;\" src=\"https://static.tibia.com/images/news/emeraldraven_small.jpg\" onclick=\"ImageInNewWindow(&#39;https://static.tibia.com/images/news/emeraldraven.jpg&#39;)\"/></center>\n<figcaption><center><em>Click on image to enlarge.</em></center></figcaption>\n</figure>\n<p>Once bought, your character can use the mount ingame anytime, no matter if you are a free account or a Premium account.</p>\n<p>Get yourself a corvid companion!<br/>Your Community Managers</p> ", newsArticleJson.News.ContentHTML)
 }

--- a/src/TibiaNewslist.go
+++ b/src/TibiaNewslist.go
@@ -86,7 +86,7 @@ func TibiaNewslistImpl(days int, BoxContentHTML string) (NewsListResponse, error
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			Link:       "https://www.tibia.com/news/?subtopic=newsarchive",
+			TibiaURL:       "https://www.tibia.com/news/?subtopic=newsarchive",
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaNewslist.go
+++ b/src/TibiaNewslist.go
@@ -86,7 +86,7 @@ func TibiaNewslistImpl(days int, BoxContentHTML string) (NewsListResponse, error
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			Link:       "",
+			Link:       "https://www.tibia.com/news/?subtopic=newsarchive",
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaNewslist.go
+++ b/src/TibiaNewslist.go
@@ -26,7 +26,7 @@ type NewsListResponse struct {
 	Information Information `json:"information"`
 }
 
-func TibiaNewslistImpl(days int, BoxContentHTML string) (NewsListResponse, error) {
+func TibiaNewslistImpl(days int, BoxContentHTML string, handlerURL string) (NewsListResponse, error) {
 	// Declaring vars for later use..
 	var NewsListData []NewsItem
 
@@ -86,7 +86,7 @@ func TibiaNewslistImpl(days int, BoxContentHTML string) (NewsListResponse, error
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURL:       "https://www.tibia.com/news/?subtopic=newsarchive",
+			TibiaURL:   []string{handlerURL},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaNewslist.go
+++ b/src/TibiaNewslist.go
@@ -86,6 +86,7 @@ func TibiaNewslistImpl(days int, BoxContentHTML string) (NewsListResponse, error
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
+			Link:       "",
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaNewslist.go
+++ b/src/TibiaNewslist.go
@@ -16,7 +16,7 @@ type NewsItem struct {
 	News     string `json:"news"`              // The news in plain text.
 	Category string `json:"category"`          // The category of the news.
 	Type     string `json:"type"`              // The type of news.
-	TibiaURL string `json:"url"`               // The URL for the news with id.
+	TibiaURLs string `json:"url"`               // The URL for the news with id.
 	ApiURL   string `json:"url_api,omitempty"` // The URL for the news in this API.
 }
 
@@ -63,7 +63,7 @@ func TibiaNewslistImpl(days int, BoxContentHTML string, handlerURL string) (News
 		NewsID := p.Query().Get("id")
 		NewsSplit := strings.Split(NewsURL, NewsID)
 		OneNews.ID = TibiaDataStringToInteger(NewsID)
-		OneNews.TibiaURL = NewsSplit[0] + NewsID
+		OneNews.TibiaURLs = NewsSplit[0] + NewsID
 
 		if TibiaDataHost != "" {
 			OneNews.ApiURL = "https://" + TibiaDataHost + "/v4/news/id/" + NewsID
@@ -86,7 +86,7 @@ func TibiaNewslistImpl(days int, BoxContentHTML string, handlerURL string) (News
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURL:   []string{handlerURL},
+			TibiaURLs:   []string{handlerURL},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaNewslist.go
+++ b/src/TibiaNewslist.go
@@ -16,7 +16,7 @@ type NewsItem struct {
 	News     string `json:"news"`              // The news in plain text.
 	Category string `json:"category"`          // The category of the news.
 	Type     string `json:"type"`              // The type of news.
-	TibiaURLs string `json:"url"`               // The URL for the news with id.
+	TibiaURL string `json:"url"`               // The URL for the news with id.
 	ApiURL   string `json:"url_api,omitempty"` // The URL for the news in this API.
 }
 
@@ -63,7 +63,7 @@ func TibiaNewslistImpl(days int, BoxContentHTML string, handlerURL string) (News
 		NewsID := p.Query().Get("id")
 		NewsSplit := strings.Split(NewsURL, NewsID)
 		OneNews.ID = TibiaDataStringToInteger(NewsID)
-		OneNews.TibiaURLs = NewsSplit[0] + NewsID
+		OneNews.TibiaURL = NewsSplit[0] + NewsID
 
 		if TibiaDataHost != "" {
 			OneNews.ApiURL = "https://" + TibiaDataHost + "/v4/news/id/" + NewsID
@@ -86,7 +86,7 @@ func TibiaNewslistImpl(days int, BoxContentHTML string, handlerURL string) (News
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURLs:   []string{handlerURL},
+			TibiaURLs:  []string{handlerURL},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaNewslist_test.go
+++ b/src/TibiaNewslist_test.go
@@ -22,7 +22,7 @@ func TestNewsList(t *testing.T) {
 
 	TibiaDataHost = "unittest.example.com"
 
-	newsListJson, err := TibiaNewslistImpl(90, string(data))
+	newsListJson, err := TibiaNewslistImpl(90, string(data), "https://www.tibia.com/news/?subtopic=newsarchive")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -30,7 +30,7 @@ func TestNewsList(t *testing.T) {
 	assert := assert.New(t)
 	information := newsListJson.Information
 
-	assert.Equal("https://www.tibia.com/news/?subtopic=newsarchive", information.TibiaURL)
+	assert.Equal("https://www.tibia.com/news/?subtopic=newsarchive", information.TibiaURL[0])
 
 	assert.Equal(50, len(newsListJson.News))
 

--- a/src/TibiaNewslist_test.go
+++ b/src/TibiaNewslist_test.go
@@ -28,6 +28,9 @@ func TestNewsList(t *testing.T) {
 	}
 
 	assert := assert.New(t)
+	information := newsListJson.Information
+
+	assert.Equal("https://www.tibia.com/news/?subtopic=newsarchive", information.Link)
 
 	assert.Equal(50, len(newsListJson.News))
 

--- a/src/TibiaNewslist_test.go
+++ b/src/TibiaNewslist_test.go
@@ -30,7 +30,7 @@ func TestNewsList(t *testing.T) {
 	assert := assert.New(t)
 	information := newsListJson.Information
 
-	assert.Equal("https://www.tibia.com/news/?subtopic=newsarchive", information.Link)
+	assert.Equal("https://www.tibia.com/news/?subtopic=newsarchive", information.TibiaURL)
 
 	assert.Equal(50, len(newsListJson.News))
 

--- a/src/TibiaNewslist_test.go
+++ b/src/TibiaNewslist_test.go
@@ -30,7 +30,7 @@ func TestNewsList(t *testing.T) {
 	assert := assert.New(t)
 	information := newsListJson.Information
 
-	assert.Equal("https://www.tibia.com/news/?subtopic=newsarchive", information.TibiaURL[0])
+	assert.Equal("https://www.tibia.com/news/?subtopic=newsarchive", information.TibiaURLs[0])
 
 	assert.Equal(50, len(newsListJson.News))
 
@@ -40,6 +40,6 @@ func TestNewsList(t *testing.T) {
 	assert.Equal("A number of issues related to the 25 years activities have been fixed,...", firstArticle.News)
 	assert.Equal("development", firstArticle.Category)
 	assert.Equal("ticker", firstArticle.Type)
-	assert.Equal("https://www.tibia.com/news/?subtopic=newsarchive&id=6529", firstArticle.TibiaURL)
+	assert.Equal("https://www.tibia.com/news/?subtopic=newsarchive&id=6529", firstArticle.TibiaURLs)
 	assert.Equal("https://unittest.example.com/v4/news/id/6529", firstArticle.ApiURL)
 }

--- a/src/TibiaNewslist_test.go
+++ b/src/TibiaNewslist_test.go
@@ -40,6 +40,6 @@ func TestNewsList(t *testing.T) {
 	assert.Equal("A number of issues related to the 25 years activities have been fixed,...", firstArticle.News)
 	assert.Equal("development", firstArticle.Category)
 	assert.Equal("ticker", firstArticle.Type)
-	assert.Equal("https://www.tibia.com/news/?subtopic=newsarchive&id=6529", firstArticle.TibiaURLs)
+	assert.Equal("https://www.tibia.com/news/?subtopic=newsarchive&id=6529", firstArticle.TibiaURL)
 	assert.Equal("https://unittest.example.com/v4/news/id/6529", firstArticle.ApiURL)
 }

--- a/src/TibiaSpellsOverview.go
+++ b/src/TibiaSpellsOverview.go
@@ -37,7 +37,7 @@ type SpellsOverviewResponse struct {
 }
 
 // TibiaSpellsOverview func
-func TibiaSpellsOverviewImpl(vocationName string, BoxContentHTML string) (SpellsOverviewResponse, error) {
+func TibiaSpellsOverviewImpl(vocationName string, BoxContentHTML string, url string) (SpellsOverviewResponse, error) {
 	// Loading HTML data into ReaderHTML for goquery with NewReader
 	ReaderHTML, err := goquery.NewDocumentFromReader(strings.NewReader(BoxContentHTML))
 	if err != nil {
@@ -122,7 +122,7 @@ func TibiaSpellsOverviewImpl(vocationName string, BoxContentHTML string) (Spells
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURL:       "https://www.tibia.com/library/?subtopic=spells",
+			TibiaURL:   []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaSpellsOverview.go
+++ b/src/TibiaSpellsOverview.go
@@ -122,7 +122,7 @@ func TibiaSpellsOverviewImpl(vocationName string, BoxContentHTML string) (Spells
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			Link:       "https://www.tibia.com/library/?subtopic=spells",
+			TibiaURL:       "https://www.tibia.com/library/?subtopic=spells",
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaSpellsOverview.go
+++ b/src/TibiaSpellsOverview.go
@@ -48,7 +48,7 @@ func TibiaSpellsOverviewImpl(vocationName string, BoxContentHTML string) (Spells
 
 	// Running query over each div
 	ReaderHTML.Find(".Table3 table.TableContent tr").Each(func(index int, s *goquery.Selection) {
-		//Skip header row
+		// Skip header row
 		if index == 0 {
 			return
 		}
@@ -122,6 +122,7 @@ func TibiaSpellsOverviewImpl(vocationName string, BoxContentHTML string) (Spells
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
+			Link:       "https://www.tibia.com/library/?subtopic=spells",
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaSpellsOverview.go
+++ b/src/TibiaSpellsOverview.go
@@ -122,7 +122,7 @@ func TibiaSpellsOverviewImpl(vocationName string, BoxContentHTML string, url str
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURLs:   []string{url},
+			TibiaURLs:  []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaSpellsOverview.go
+++ b/src/TibiaSpellsOverview.go
@@ -122,7 +122,7 @@ func TibiaSpellsOverviewImpl(vocationName string, BoxContentHTML string, url str
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURL:   []string{url},
+			TibiaURLs:   []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaSpellsOverview_test.go
+++ b/src/TibiaSpellsOverview_test.go
@@ -26,6 +26,9 @@ func TestOverviewAll(t *testing.T) {
 	}
 
 	assert := assert.New(t)
+	information := spellsOverviewJson.Information
+
+	assert.Equal("https://www.tibia.com/library/?subtopic=spells", information.Link)
 
 	assert.Equal(152, len(spellsOverviewJson.Spells.Spells))
 

--- a/src/TibiaSpellsOverview_test.go
+++ b/src/TibiaSpellsOverview_test.go
@@ -28,7 +28,7 @@ func TestOverviewAll(t *testing.T) {
 	assert := assert.New(t)
 	information := spellsOverviewJson.Information
 
-	assert.Equal("https://www.tibia.com/library/?subtopic=spells", information.Link)
+	assert.Equal("https://www.tibia.com/library/?subtopic=spells", information.TibiaURL)
 
 	assert.Equal(152, len(spellsOverviewJson.Spells.Spells))
 

--- a/src/TibiaSpellsOverview_test.go
+++ b/src/TibiaSpellsOverview_test.go
@@ -20,7 +20,7 @@ func TestOverviewAll(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	spellsOverviewJson, err := TibiaSpellsOverviewImpl("", string(data))
+	spellsOverviewJson, err := TibiaSpellsOverviewImpl("", string(data), "https://www.tibia.com/library/?subtopic=spells")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -28,7 +28,7 @@ func TestOverviewAll(t *testing.T) {
 	assert := assert.New(t)
 	information := spellsOverviewJson.Information
 
-	assert.Equal("https://www.tibia.com/library/?subtopic=spells", information.TibiaURL)
+	assert.Equal("https://www.tibia.com/library/?subtopic=spells", information.TibiaURL[0])
 
 	assert.Equal(152, len(spellsOverviewJson.Spells.Spells))
 
@@ -78,7 +78,7 @@ func TestOverviewDruid(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	spellsOverviewJson, err := TibiaSpellsOverviewImpl("druid", string(data))
+	spellsOverviewJson, err := TibiaSpellsOverviewImpl("druid", string(data), "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/TibiaSpellsOverview_test.go
+++ b/src/TibiaSpellsOverview_test.go
@@ -28,7 +28,7 @@ func TestOverviewAll(t *testing.T) {
 	assert := assert.New(t)
 	information := spellsOverviewJson.Information
 
-	assert.Equal("https://www.tibia.com/library/?subtopic=spells", information.TibiaURL[0])
+	assert.Equal("https://www.tibia.com/library/?subtopic=spells", information.TibiaURLs[0])
 
 	assert.Equal(152, len(spellsOverviewJson.Spells.Spells))
 

--- a/src/TibiaSpellsSpell.go
+++ b/src/TibiaSpellsSpell.go
@@ -67,7 +67,7 @@ var (
 )
 
 // TibiaSpellsSpell func
-func TibiaSpellsSpellImpl(spell string, BoxContentHTML string) (SpellInformationResponse, error) {
+func TibiaSpellsSpellImpl(spell string, BoxContentHTML string, url string) (SpellInformationResponse, error) {
 	// TODO: There is currently a bug with description, it always comes back empty
 
 	// Loading HTML data into ReaderHTML for goquery with NewReader
@@ -313,7 +313,7 @@ func TibiaSpellsSpellImpl(spell string, BoxContentHTML string) (SpellInformation
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURL:       "https://www.tibia.com/library/?subtopic=spells&spell=" + SpellID,
+			TibiaURL:   []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaSpellsSpell.go
+++ b/src/TibiaSpellsSpell.go
@@ -313,7 +313,7 @@ func TibiaSpellsSpellImpl(spell string, BoxContentHTML string) (SpellInformation
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			Link:       "https://www.tibia.com/library/?subtopic=spells&spell=" + SpellID,
+			TibiaURL:       "https://www.tibia.com/library/?subtopic=spells&spell=" + SpellID,
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaSpellsSpell.go
+++ b/src/TibiaSpellsSpell.go
@@ -68,7 +68,7 @@ var (
 
 // TibiaSpellsSpell func
 func TibiaSpellsSpellImpl(spell string, BoxContentHTML string) (SpellInformationResponse, error) {
-	//TODO: There is currently a bug with description, it always comes back empty
+	// TODO: There is currently a bug with description, it always comes back empty
 
 	// Loading HTML data into ReaderHTML for goquery with NewReader
 	ReaderHTML, err := goquery.NewDocumentFromReader(strings.NewReader(BoxContentHTML))
@@ -313,6 +313,7 @@ func TibiaSpellsSpellImpl(spell string, BoxContentHTML string) (SpellInformation
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
+			Link:       "https://www.tibia.com/library/?subtopic=spells&spell=" + SpellID,
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaSpellsSpell.go
+++ b/src/TibiaSpellsSpell.go
@@ -313,7 +313,7 @@ func TibiaSpellsSpellImpl(spell string, BoxContentHTML string, url string) (Spel
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURL:   []string{url},
+			TibiaURLs:   []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaSpellsSpell.go
+++ b/src/TibiaSpellsSpell.go
@@ -313,7 +313,7 @@ func TibiaSpellsSpellImpl(spell string, BoxContentHTML string, url string) (Spel
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURLs:   []string{url},
+			TibiaURLs:  []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaSpellsSpell_test.go
+++ b/src/TibiaSpellsSpell_test.go
@@ -29,7 +29,7 @@ func TestFindPerson(t *testing.T) {
 	spell := findPersonJson.Spell
 	information := findPersonJson.Information
 
-	assert.Equal("https://www.tibia.com/library/?subtopic=spells&spell=findperson", information.Link)
+	assert.Equal("https://www.tibia.com/library/?subtopic=spells&spell=findperson", information.TibiaURL)
 
 	assert.Empty(spell.Description)
 	assert.Equal("Find Person", spell.Name)

--- a/src/TibiaSpellsSpell_test.go
+++ b/src/TibiaSpellsSpell_test.go
@@ -27,6 +27,9 @@ func TestFindPerson(t *testing.T) {
 
 	assert := assert.New(t)
 	spell := findPersonJson.Spell
+	information := findPersonJson.Information
+
+	assert.Equal("https://www.tibia.com/library/?subtopic=spells&spell=findperson", information.Link)
 
 	assert.Empty(spell.Description)
 	assert.Equal("Find Person", spell.Name)

--- a/src/TibiaSpellsSpell_test.go
+++ b/src/TibiaSpellsSpell_test.go
@@ -20,7 +20,7 @@ func TestFindPerson(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	findPersonJson, err := TibiaSpellsSpellImpl("Find Person", string(data))
+	findPersonJson, err := TibiaSpellsSpellImpl("Find Person", string(data), "https://www.tibia.com/library/?subtopic=spells&spell=findperson")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +71,7 @@ func TestHeavyMagicMissileRune(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	hmmJson, err := TibiaSpellsSpellImpl("Heavy Magic Missile Rune", string(data))
+	hmmJson, err := TibiaSpellsSpellImpl("Heavy Magic Missile Rune", string(data), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -130,7 +130,7 @@ func TestAnnihilation(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	annihilationJson, err := TibiaSpellsSpellImpl("Annihilation", string(data))
+	annihilationJson, err := TibiaSpellsSpellImpl("Annihilation", string(data), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -173,7 +173,7 @@ func TestBruiseBane(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	bruisebaneJson, err := TibiaSpellsSpellImpl("Bruise Bane", string(data))
+	bruisebaneJson, err := TibiaSpellsSpellImpl("Bruise Bane", string(data), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -216,7 +216,7 @@ func TestCurePoisonRune(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	curepoisonruneJson, err := TibiaSpellsSpellImpl("Cure Poison Rune", string(data))
+	curepoisonruneJson, err := TibiaSpellsSpellImpl("Cure Poison Rune", string(data), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -255,7 +255,7 @@ func TestConvinceCreatureRune(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	convincecreatureruneJson, err := TibiaSpellsSpellImpl("Convince Creature Rune", string(data))
+	convincecreatureruneJson, err := TibiaSpellsSpellImpl("Convince Creature Rune", string(data), "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/TibiaSpellsSpell_test.go
+++ b/src/TibiaSpellsSpell_test.go
@@ -29,7 +29,7 @@ func TestFindPerson(t *testing.T) {
 	spell := findPersonJson.Spell
 	information := findPersonJson.Information
 
-	assert.Equal("https://www.tibia.com/library/?subtopic=spells&spell=findperson", information.TibiaURLs)
+	assert.Equal("https://www.tibia.com/library/?subtopic=spells&spell=findperson", information.TibiaURLs[0])
 
 	assert.Empty(spell.Description)
 	assert.Equal("Find Person", spell.Name)

--- a/src/TibiaSpellsSpell_test.go
+++ b/src/TibiaSpellsSpell_test.go
@@ -29,7 +29,7 @@ func TestFindPerson(t *testing.T) {
 	spell := findPersonJson.Spell
 	information := findPersonJson.Information
 
-	assert.Equal("https://www.tibia.com/library/?subtopic=spells&spell=findperson", information.TibiaURL)
+	assert.Equal("https://www.tibia.com/library/?subtopic=spells&spell=findperson", information.TibiaURLs)
 
 	assert.Empty(spell.Description)
 	assert.Equal("Find Person", spell.Name)

--- a/src/TibiaWorldsOverview.go
+++ b/src/TibiaWorldsOverview.go
@@ -206,7 +206,7 @@ func TibiaWorldsOverviewImpl(BoxContentHTML string) (WorldsOverviewResponse, err
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			Link:       "https://www.tibia.com/community/?subtopic=worlds",
+			TibiaURL:       "https://www.tibia.com/community/?subtopic=worlds",
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaWorldsOverview.go
+++ b/src/TibiaWorldsOverview.go
@@ -206,6 +206,7 @@ func TibiaWorldsOverviewImpl(BoxContentHTML string) (WorldsOverviewResponse, err
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
+			Link:       "https://www.tibia.com/community/?subtopic=worlds",
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaWorldsOverview.go
+++ b/src/TibiaWorldsOverview.go
@@ -46,7 +46,7 @@ var (
 )
 
 // TibiaWorldsOverview func
-func TibiaWorldsOverviewImpl(BoxContentHTML string) (WorldsOverviewResponse, error) {
+func TibiaWorldsOverviewImpl(BoxContentHTML string, url string) (WorldsOverviewResponse, error) {
 	// Loading HTML data into ReaderHTML for goquery with NewReader
 	ReaderHTML, err := goquery.NewDocumentFromReader(strings.NewReader(BoxContentHTML))
 	if err != nil {
@@ -206,7 +206,7 @@ func TibiaWorldsOverviewImpl(BoxContentHTML string) (WorldsOverviewResponse, err
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURL:       "https://www.tibia.com/community/?subtopic=worlds",
+			TibiaURL:   []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaWorldsOverview.go
+++ b/src/TibiaWorldsOverview.go
@@ -206,7 +206,7 @@ func TibiaWorldsOverviewImpl(BoxContentHTML string, url string) (WorldsOverviewR
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURL:   []string{url},
+			TibiaURLs:   []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaWorldsOverview.go
+++ b/src/TibiaWorldsOverview.go
@@ -206,7 +206,7 @@ func TibiaWorldsOverviewImpl(BoxContentHTML string, url string) (WorldsOverviewR
 		Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURLs:   []string{url},
+			TibiaURLs:  []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaWorldsOverview_test.go
+++ b/src/TibiaWorldsOverview_test.go
@@ -20,7 +20,7 @@ func TestWorlds(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	worldsJson, err := TibiaWorldsOverviewImpl(string(data))
+	worldsJson, err := TibiaWorldsOverviewImpl(string(data), "https://www.tibia.com/community/?subtopic=worlds")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -28,7 +28,7 @@ func TestWorlds(t *testing.T) {
 	assert := assert.New(t)
 	information := worldsJson.Information
 
-	assert.Equal("https://www.tibia.com/community/?subtopic=worlds", information.TibiaURL)
+	assert.Equal("https://www.tibia.com/community/?subtopic=worlds", information.TibiaURL[0])
 
 	assert.Equal(8720, worldsJson.Worlds.PlayersOnline)
 	assert.Equal(64028, worldsJson.Worlds.RecordPlayers)

--- a/src/TibiaWorldsOverview_test.go
+++ b/src/TibiaWorldsOverview_test.go
@@ -28,7 +28,7 @@ func TestWorlds(t *testing.T) {
 	assert := assert.New(t)
 	information := worldsJson.Information
 
-	assert.Equal("https://www.tibia.com/community/?subtopic=worlds", information.Link)
+	assert.Equal("https://www.tibia.com/community/?subtopic=worlds", information.TibiaURL)
 
 	assert.Equal(8720, worldsJson.Worlds.PlayersOnline)
 	assert.Equal(64028, worldsJson.Worlds.RecordPlayers)

--- a/src/TibiaWorldsOverview_test.go
+++ b/src/TibiaWorldsOverview_test.go
@@ -26,6 +26,9 @@ func TestWorlds(t *testing.T) {
 	}
 
 	assert := assert.New(t)
+	information := worldsJson.Information
+
+	assert.Equal("https://www.tibia.com/community/?subtopic=worlds", information.Link)
 
 	assert.Equal(8720, worldsJson.Worlds.PlayersOnline)
 	assert.Equal(64028, worldsJson.Worlds.RecordPlayers)

--- a/src/TibiaWorldsOverview_test.go
+++ b/src/TibiaWorldsOverview_test.go
@@ -28,7 +28,7 @@ func TestWorlds(t *testing.T) {
 	assert := assert.New(t)
 	information := worldsJson.Information
 
-	assert.Equal("https://www.tibia.com/community/?subtopic=worlds", information.TibiaURL[0])
+	assert.Equal("https://www.tibia.com/community/?subtopic=worlds", information.TibiaURLs[0])
 
 	assert.Equal(8720, worldsJson.Worlds.PlayersOnline)
 	assert.Equal(64028, worldsJson.Worlds.RecordPlayers)

--- a/src/TibiaWorldsWorld.go
+++ b/src/TibiaWorldsWorld.go
@@ -51,7 +51,7 @@ var (
 
 // TibiaWorldsWorld func
 func TibiaWorldsWorldImpl(world string, BoxContentHTML string) (WorldResponse, error) {
-	//TODO: We need to read the world name from the response rather than pass it into this func
+	// TODO: We need to read the world name from the response rather than pass it into this func
 
 	// Loading HTML data into ReaderHTML for goquery with NewReader
 	ReaderHTML, err := goquery.NewDocumentFromReader(strings.NewReader(BoxContentHTML))
@@ -230,6 +230,7 @@ func TibiaWorldsWorldImpl(world string, BoxContentHTML string) (WorldResponse, e
 		Information: Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
+			Link:       "https://www.tibia.com/community/?subtopic=worlds&world=" + world,
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaWorldsWorld.go
+++ b/src/TibiaWorldsWorld.go
@@ -50,7 +50,7 @@ var (
 )
 
 // TibiaWorldsWorld func
-func TibiaWorldsWorldImpl(world string, BoxContentHTML string) (WorldResponse, error) {
+func TibiaWorldsWorldImpl(world string, BoxContentHTML string, url string) (WorldResponse, error) {
 	// TODO: We need to read the world name from the response rather than pass it into this func
 
 	// Loading HTML data into ReaderHTML for goquery with NewReader
@@ -230,7 +230,7 @@ func TibiaWorldsWorldImpl(world string, BoxContentHTML string) (WorldResponse, e
 		Information: Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURL:       "https://www.tibia.com/community/?subtopic=worlds&world=" + world,
+			TibiaURL:   []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaWorldsWorld.go
+++ b/src/TibiaWorldsWorld.go
@@ -230,7 +230,7 @@ func TibiaWorldsWorldImpl(world string, BoxContentHTML string) (WorldResponse, e
 		Information: Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			Link:       "https://www.tibia.com/community/?subtopic=worlds&world=" + world,
+			TibiaURL:       "https://www.tibia.com/community/?subtopic=worlds&world=" + world,
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaWorldsWorld.go
+++ b/src/TibiaWorldsWorld.go
@@ -230,7 +230,7 @@ func TibiaWorldsWorldImpl(world string, BoxContentHTML string, url string) (Worl
 		Information: Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURLs:   []string{url},
+			TibiaURLs:  []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaWorldsWorld.go
+++ b/src/TibiaWorldsWorld.go
@@ -230,7 +230,7 @@ func TibiaWorldsWorldImpl(world string, BoxContentHTML string, url string) (Worl
 		Information: Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURL:   []string{url},
+			TibiaURLs:   []string{url},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 			},

--- a/src/TibiaWorldsWorld_test.go
+++ b/src/TibiaWorldsWorld_test.go
@@ -29,7 +29,7 @@ func TestWorldEndebra(t *testing.T) {
 	world := worldJson.World
 	information := worldJson.Information
 
-	assert.Equal("https://www.tibia.com/community/?subtopic=worlds&world=Endebra", information.Link)
+	assert.Equal("https://www.tibia.com/community/?subtopic=worlds&world=Endebra", information.TibiaURL)
 
 	assert.Equal("Endebra", world.Name)
 	assert.Equal("online", world.Status)

--- a/src/TibiaWorldsWorld_test.go
+++ b/src/TibiaWorldsWorld_test.go
@@ -20,7 +20,7 @@ func TestWorldEndebra(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	worldJson, err := TibiaWorldsWorldImpl("Endebra", string(data))
+	worldJson, err := TibiaWorldsWorldImpl("Endebra", string(data), "https://www.tibia.com/community/?subtopic=worlds&world=Endebra")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +29,7 @@ func TestWorldEndebra(t *testing.T) {
 	world := worldJson.World
 	information := worldJson.Information
 
-	assert.Equal("https://www.tibia.com/community/?subtopic=worlds&world=Endebra", information.TibiaURL)
+	assert.Equal("https://www.tibia.com/community/?subtopic=worlds&world=Endebra", information.TibiaURL[0])
 
 	assert.Equal("Endebra", world.Name)
 	assert.Equal("online", world.Status)
@@ -61,7 +61,7 @@ func TestWorldPremia(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	worldJson, err := TibiaWorldsWorldImpl("Premia", string(data))
+	worldJson, err := TibiaWorldsWorldImpl("Premia", string(data), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,7 +103,7 @@ func TestWorldWintera(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	worldJson, err := TibiaWorldsWorldImpl("Wintera", string(data))
+	worldJson, err := TibiaWorldsWorldImpl("Wintera", string(data), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -150,7 +150,7 @@ func TestWorldZuna(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	worldJson, err := TibiaWorldsWorldImpl("Zuna", string(data))
+	worldJson, err := TibiaWorldsWorldImpl("Zuna", string(data), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -195,7 +195,7 @@ func TestWorldOceanis(t *testing.T) {
 		t.Fatalf("File reading error: %s", err)
 	}
 
-	worldJson, err := TibiaWorldsWorldImpl("Oceanis", string(data))
+	worldJson, err := TibiaWorldsWorldImpl("Oceanis", string(data), "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/TibiaWorldsWorld_test.go
+++ b/src/TibiaWorldsWorld_test.go
@@ -27,6 +27,9 @@ func TestWorldEndebra(t *testing.T) {
 
 	assert := assert.New(t)
 	world := worldJson.World
+	information := worldJson.Information
+
+	assert.Equal("https://www.tibia.com/community/?subtopic=worlds&world=Endebra", information.Link)
 
 	assert.Equal("Endebra", world.Name)
 	assert.Equal("online", world.Status)
@@ -87,6 +90,7 @@ func TestWorldPremia(t *testing.T) {
 	assert.Empty(world.TournamentWorldType)
 	assert.Equal(0, len(world.OnlinePlayers))
 }
+
 func TestWorldWintera(t *testing.T) {
 	file, err := static.TestFiles.Open("testdata/worlds/world/Wintera.html")
 	if err != nil {

--- a/src/TibiaWorldsWorld_test.go
+++ b/src/TibiaWorldsWorld_test.go
@@ -29,7 +29,7 @@ func TestWorldEndebra(t *testing.T) {
 	world := worldJson.World
 	information := worldJson.Information
 
-	assert.Equal("https://www.tibia.com/community/?subtopic=worlds&world=Endebra", information.TibiaURL[0])
+	assert.Equal("https://www.tibia.com/community/?subtopic=worlds&world=Endebra", information.TibiaURLs[0])
 
 	assert.Equal("Endebra", world.Name)
 	assert.Equal("online", world.Status)

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -440,7 +440,7 @@ func tibiaGuildsGuild(c *gin.Context) {
 		c,
 		tibiadataRequest,
 		func(BoxContentHTML string) (interface{}, error) {
-			return TibiaGuildsGuildImpl(guild, BoxContentHTML)
+			return TibiaGuildsGuildImpl(guild, BoxContentHTML, tibiadataRequest.URL)
 		},
 		"TibiaGuildsGuild")
 }

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -485,7 +485,7 @@ func tibiaGuildsOverview(c *gin.Context) {
 		c,
 		tibiadataRequest,
 		func(BoxContentHTML string) (interface{}, error) {
-			return TibiaGuildsOverviewImpl(world, BoxContentHTML)
+			return TibiaGuildsOverviewImpl(world, BoxContentHTML, tibiadataRequest.URL)
 		},
 		"TibiaGuildsOverview")
 }
@@ -578,7 +578,7 @@ func tibiaHighscores(c *gin.Context) {
 		c,
 		tibiadataRequest,
 		func(BoxContentHTML string) (interface{}, error) {
-			return TibiaHighscoresImpl(world, highscoreCategory, vocationName, TibiaDataStringToInteger(page), BoxContentHTML)
+			return TibiaHighscoresImpl(world, highscoreCategory, vocationName, TibiaDataStringToInteger(page), BoxContentHTML, tibiadataRequest.URL)
 		},
 		"TibiaHighscores")
 }

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -47,6 +47,7 @@ type OutInformation struct {
 type Information struct {
 	APIDetails APIDetails `json:"api"`       // The API details.
 	Timestamp  string     `json:"timestamp"` // The timestamp from when the data was processed.
+	Link       string     `json:"link"`      // The link to the source of the data.
 	Status     Status     `json:"status"`    // The response status information.
 }
 

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -971,7 +971,7 @@ func tibiaSpellsOverview(c *gin.Context) {
 		c,
 		tibiadataRequest,
 		func(BoxContentHTML string) (interface{}, error) {
-			return TibiaSpellsOverviewImpl(vocationName, BoxContentHTML)
+			return TibiaSpellsOverviewImpl(vocationName, BoxContentHTML, tibiadataRequest.URL)
 		},
 		"TibiaSpellsOverview")
 }
@@ -1007,7 +1007,7 @@ func tibiaSpellsSpell(c *gin.Context) {
 		c,
 		tibiadataRequest,
 		func(BoxContentHTML string) (interface{}, error) {
-			return TibiaSpellsSpellImpl(spell, BoxContentHTML)
+			return TibiaSpellsSpellImpl(spell, BoxContentHTML, tibiadataRequest.URL)
 		},
 		"TibiaSpellsSpell")
 }

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -403,7 +403,7 @@ func tibiaFansites(c *gin.Context) {
 		c,
 		tibiadataRequest,
 		func(BoxContentHTML string) (interface{}, error) {
-			return TibiaFansitesImpl(BoxContentHTML)
+			return TibiaFansitesImpl(BoxContentHTML, tibiadataRequest.URL)
 		},
 		"TibiaFansites")
 }

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -47,7 +47,7 @@ type OutInformation struct {
 type Information struct {
 	APIDetails APIDetails `json:"api"`       // The API details.
 	Timestamp  string     `json:"timestamp"` // The timestamp from when the data was processed.
-	Link       string     `json:"link"`      // The link to the source of the data.
+	TibiaURL   []string   `json:"tibia_url"` // The links to the sources of the data on tibia.com.
 	Status     Status     `json:"status"`    // The response status information.
 }
 
@@ -122,7 +122,7 @@ func runWebServer() {
 		data := Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			Link:       "-",
+			TibiaURL:   []string{},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 				Message:  "pong",
@@ -1091,7 +1091,7 @@ func TibiaDataErrorHandler(c *gin.Context, err error, httpCode int) {
 	info := Information{
 		APIDetails: TibiaDataAPIDetails,
 		Timestamp:  TibiaDataDatetime(""),
-		Link:       "-",
+		TibiaURL:   []string{},
 		Status: Status{
 			HTTPCode: httpCode,
 		},

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -879,7 +879,7 @@ func tibiaNewslist(c *gin.Context) {
 		c,
 		tibiadataRequest,
 		func(BoxContentHTML string) (interface{}, error) {
-			return TibiaNewslistImpl(days, BoxContentHTML)
+			return TibiaNewslistImpl(days, BoxContentHTML, tibiadataRequest.URL)
 		},
 		"TibiaNewslist")
 }

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -340,7 +340,7 @@ func tibiaCreaturesOverview(c *gin.Context) {
 		c,
 		tibiadataRequest,
 		func(BoxContentHTML string) (interface{}, error) {
-			return TibiaCreaturesOverviewImpl(BoxContentHTML)
+			return TibiaCreaturesOverviewImpl(BoxContentHTML, tibiadataRequest.URL)
 		},
 		"TibiaCreaturesOverview")
 }
@@ -377,7 +377,7 @@ func tibiaCreaturesCreature(c *gin.Context) {
 		c,
 		tibiadataRequest,
 		func(BoxContentHTML string) (interface{}, error) {
-			return TibiaCreaturesCreatureImpl(endpoint, BoxContentHTML)
+			return TibiaCreaturesCreatureImpl(endpoint, BoxContentHTML, tibiadataRequest.URL)
 		},
 		"TibiaCreaturesCreature")
 }

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -122,6 +122,7 @@ func runWebServer() {
 		data := Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
+			Link:       "-",
 			Status: Status{
 				HTTPCode: http.StatusOK,
 				Message:  "pong",
@@ -1090,6 +1091,7 @@ func TibiaDataErrorHandler(c *gin.Context, err error, httpCode int) {
 	info := Information{
 		APIDetails: TibiaDataAPIDetails,
 		Timestamp:  TibiaDataDatetime(""),
+		Link:       "-",
 		Status: Status{
 			HTTPCode: httpCode,
 		},

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -643,7 +643,7 @@ func tibiaHousesHouse(c *gin.Context) {
 		c,
 		tibiadataRequest,
 		func(BoxContentHTML string) (interface{}, error) {
-			return TibiaHousesHouseImpl(houseid, BoxContentHTML)
+			return TibiaHousesHouseImpl(houseid, BoxContentHTML, tibiadataRequest.URL)
 		},
 		"TibiaHousesHouse")
 }

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -314,7 +314,7 @@ func tibiaCharactersCharacter(c *gin.Context) {
 		c,
 		tibiadataRequest,
 		func(BoxContentHTML string) (interface{}, error) {
-			return TibiaCharactersCharacterImpl(BoxContentHTML)
+			return TibiaCharactersCharacterImpl(BoxContentHTML, tibiadataRequest.URL)
 		},
 		"TibiaCharactersCharacter")
 }

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -275,7 +275,7 @@ func tibiaBoostableBosses(c *gin.Context) {
 		c,
 		tibiadataRequest,
 		func(BoxContentHTML string) (interface{}, error) {
-			return TibiaBoostableBossesOverviewImpl(BoxContentHTML)
+			return TibiaBoostableBossesOverviewImpl(BoxContentHTML, tibiadataRequest.URL)
 		},
 		"TibiaBoostableBosses")
 }

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -1033,7 +1033,7 @@ func tibiaWorldsOverview(c *gin.Context) {
 		c,
 		tibiadataRequest,
 		func(BoxContentHTML string) (interface{}, error) {
-			return TibiaWorldsOverviewImpl(BoxContentHTML)
+			return TibiaWorldsOverviewImpl(BoxContentHTML, tibiadataRequest.URL)
 		},
 		"TibiaWorldsOverview")
 }
@@ -1078,7 +1078,7 @@ func tibiaWorldsWorld(c *gin.Context) {
 		c,
 		tibiadataRequest,
 		func(BoxContentHTML string) (interface{}, error) {
-			return TibiaWorldsWorldImpl(world, BoxContentHTML)
+			return TibiaWorldsWorldImpl(world, BoxContentHTML, tibiadataRequest.URL)
 		},
 		"TibiaWorldsWorld")
 }

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -751,7 +751,7 @@ func tibiaKillstatistics(c *gin.Context) {
 		c,
 		tibiadataRequest,
 		func(BoxContentHTML string) (interface{}, error) {
-			return TibiaKillstatisticsImpl(world, BoxContentHTML)
+			return TibiaKillstatisticsImpl(world, BoxContentHTML, tibiadataRequest.URL)
 		},
 		"TibiaKillstatistics")
 }

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -47,7 +47,7 @@ type OutInformation struct {
 type Information struct {
 	APIDetails APIDetails `json:"api"`       // The API details.
 	Timestamp  string     `json:"timestamp"` // The timestamp from when the data was processed.
-	TibiaURL   []string   `json:"tibia_url"` // The links to the sources of the data on tibia.com.
+	TibiaURLs   []string   `json:"tibia_url"` // The links to the sources of the data on tibia.com.
 	Status     Status     `json:"status"`    // The response status information.
 }
 
@@ -122,7 +122,7 @@ func runWebServer() {
 		data := Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURL:   []string{},
+			TibiaURLs:   []string{},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 				Message:  "pong",
@@ -1091,7 +1091,7 @@ func TibiaDataErrorHandler(c *gin.Context, err error, httpCode int) {
 	info := Information{
 		APIDetails: TibiaDataAPIDetails,
 		Timestamp:  TibiaDataDatetime(""),
-		TibiaURL:   []string{},
+		TibiaURLs:   []string{},
 		Status: Status{
 			HTTPCode: httpCode,
 		},

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -45,10 +45,10 @@ type OutInformation struct {
 
 // Information stores some API related data
 type Information struct {
-	APIDetails APIDetails `json:"api"`       // The API details.
-	Timestamp  string     `json:"timestamp"` // The timestamp from when the data was processed.
-	TibiaURLs   []string   `json:"tibia_url"` // The links to the sources of the data on tibia.com.
-	Status     Status     `json:"status"`    // The response status information.
+	APIDetails APIDetails `json:"api"`        // The API details.
+	Timestamp  string     `json:"timestamp"`  // The timestamp from when the data was processed.
+	TibiaURLs  []string   `json:"tibia_urls"` // The links to the sources of the data on tibia.com
+	Status     Status     `json:"status"`     // The response status information.
 }
 
 // API details store information about this API
@@ -122,7 +122,7 @@ func runWebServer() {
 		data := Information{
 			APIDetails: TibiaDataAPIDetails,
 			Timestamp:  TibiaDataDatetime(""),
-			TibiaURLs:   []string{},
+			TibiaURLs:  []string{},
 			Status: Status{
 				HTTPCode: http.StatusOK,
 				Message:  "pong",
@@ -1091,7 +1091,7 @@ func TibiaDataErrorHandler(c *gin.Context, err error, httpCode int) {
 	info := Information{
 		APIDetails: TibiaDataAPIDetails,
 		Timestamp:  TibiaDataDatetime(""),
-		TibiaURLs:   []string{},
+		TibiaURLs:  []string{},
 		Status: Status{
 			HTTPCode: httpCode,
 		},


### PR DESCRIPTION
This pull request addresses **Issue #381** by adding the `Link` field to the `Information` section in all API responses. The `Link` field provides a direct URL to the source data on the official Tibia website.

**Changes Overview:**

- **Updated `Information` Struct:**
  - Added a new `Link` field to the `Information` struct in `webserver.go`:
    ```go
    type Information struct {
        APIDetails APIDetails `json:"api"`       // The API details.
        Timestamp  string     `json:"timestamp"` // The timestamp from when the data was processed.
        Link       string     `json:"link"`      // The link to the source of the data.
        Status     Status     `json:"status"`    // The response status information.
    }
    ```
- **Modified API Handlers:**
  - Updated all API endpoint handlers to populate the `Link` field with the appropriate URL pointing to the source data.
  
  - Example from `TibiaWorldsWorld.go`:
  
    ```go
    return WorldResponse{
        World: World{
            // ... existing fields ...
        },
        Information: Information{
            APIDetails: TibiaDataAPIDetails,
            Timestamp:  TibiaDataDatetime(""),
            Link:       "https://www.tibia.com/community/?subtopic=worlds&world=" + world,
            Status: Status{
                HTTPCode: http.StatusOK,
            },
        },
    }, nil
    ```

**Testing:**

- Tested all modified endpoints to ensure the `Link` field is correctly populated.
- Verified that the URLs are accurate and lead to the correct pages on Tibia.com.

---

**Notes:**

- NewsList was kind of tricky to handle the different patterns so I decided to sum all different URLs into only "https://www.tibia.com/news/?subtopic=newsarchive"

- This is my first PR in the project so I am open to feedback and willing to make any necessary changes to meet the project's standards.

fix #381