### PR TITLE
feat: add root-endpoint to container

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ There is a swagger-generated documentation available for download on the [GitHub
 
 Those are the current existing endpoints.
 
+- GET `/`
 - GET `/ping`
 - GET `/healthz`
 - GET `/readyz`

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Those are the current existing endpoints.
 
 In addition to the deprecated API versions like v1, v2 and v3, there are also some endpoints that are deprecated. As of now, those are:
 
-- GET `/healthz`
+- GET `/health`
 
 ### Restricted endpoints
 

--- a/src/webserver.go
+++ b/src/webserver.go
@@ -136,6 +136,7 @@ func runWebServer() {
 	})
 
 	// health endpoints for kubernetes
+	router.GET("/", rootz)
 	router.GET("/health", healthz)
 	router.GET("/healthz", healthz)
 	router.GET("/readyz", readyz)
@@ -1303,6 +1304,15 @@ func TibiaDataHTMLDataCollector(TibiaDataRequest TibiaDataRequestStruct) (string
 
 	// Return of extracted html to functions..
 	return data, nil
+}
+
+// rootz is a root path (for helm-testing)
+func rootz(c *gin.Context) {
+	if !isReady.Load() {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": http.StatusText(http.StatusServiceUnavailable)})
+		return
+	}
+	TibiaDataAPIHandleResponse(c, "rootz", gin.H{"message": "TibiaData API up and running."})
 }
 
 // healthz is a k8s liveness probe

--- a/src/webserver_test.go
+++ b/src/webserver_test.go
@@ -244,6 +244,9 @@ func TestFakeToUpCodeCoverage(t *testing.T) {
 	tibiaWorldsWorld(c)
 	assert.Equal(http.StatusOK, w.Code)
 
+	rootz(c)
+	assert.Equal(http.StatusOK, w.Code)
+
 	healthz(c)
 	assert.Equal(http.StatusOK, w.Code)
 


### PR DESCRIPTION
This is for tools to test the container (like our testing of helm-chart in [TibiaData/tibiadata-helm-charts](https://github.com/TibiaData/tibiadata-helm-charts)) to not fail.

```plain
HTTP/1.1 404 Not Found
```