### PR TITLE
fix: omit character deaths_truncated if false

### DIFF
--- a/src/TibiaCharactersCharacter.go
+++ b/src/TibiaCharactersCharacter.go
@@ -108,7 +108,7 @@ type Character struct {
 	AccountBadges      []AccountBadges    `json:"account_badges,omitempty"`      // The account's badges.
 	Achievements       []Achievements     `json:"achievements,omitempty"`        // The character's achievements.
 	Deaths             []Deaths           `json:"deaths,omitempty"`              // The character's deaths.
-	DeathsTruncated    bool               `json:"deaths_truncated"`              // Whether the character's deaths were truncated or not.
+	DeathsTruncated    bool               `json:"deaths_truncated,omitempty"`    // Whether the character's deaths were truncated or not.
 	AccountInformation AccountInformation `json:"account_information,omitempty"` // The account information.
 	OtherCharacters    []OtherCharacters  `json:"other_characters,omitempty"`    // The account's other characters.
 }


### PR DESCRIPTION
This pull request includes a minor change to the `src/TibiaCharactersCharacter.go` file. The change involves modifying the `DeathsTruncated` field in the `Character` struct to be optional in the JSON output.

* [`src/TibiaCharactersCharacter.go`](diffhunk://#diff-e7e958291215ebb01a9df1c22d6e8ecd866edc0d2c411a490dc590d0d626214dL111-R111): Changed the `DeathsTruncated` field in the `Character` struct to include the `omitempty` tag, making it optional in the JSON output.