### PR TITLE
fix(docker): use 555 for binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN apk --no-cache add ca-certificates tzdata && \
 USER nonroot:nonroot
 
 # copy binary from builder
-COPY --from=builder --chown=nonroot:nonroot --chmod=544 /go/src/app .
+COPY --from=builder --chown=nonroot:nonroot --chmod=555 /go/src/app .
 
 # expose port 8080
 EXPOSE 8080


### PR DESCRIPTION
This pull request makes a minor adjustment to the file permissions for the application binary in the `Dockerfile`. The change increases the permissions from `544` to `555`, allowing all users to execute the binary.

When in Kubernetes another user is set (via `runAsUser`), such as `65534`, the binary fails to start because other doesn't have the execute flag on the `app` binary.