### PR TITLE
fix: remove iso-encoding for umlaut issue

### DIFF
--- a/src/TibiaDataUtils.go
+++ b/src/TibiaDataUtils.go
@@ -87,9 +87,6 @@ func TibiaDataQueryEscapeString(data string) string {
 	// switching "+" to " "
 	data = strings.ReplaceAll(data, "+", " ")
 
-	// encoding string to latin-1
-	data, _ = TibiaDataConvertEncodingtoISO88591(data)
-
 	// returning with QueryEscape function
 	return url.QueryEscape(data)
 }

--- a/src/TibiaDataUtils_test.go
+++ b/src/TibiaDataUtils_test.go
@@ -150,16 +150,19 @@ func TestEscaper(t *testing.T) {
 		strOne   = "god durin"
 		strTwo   = "god+durin"
 		strThree = "gód"
+		strFour  = "Näurin"
 	)
 
 	sanitizedStrOne := TibiaDataQueryEscapeString(strOne)
 	sanitizedStrTwo := TibiaDataQueryEscapeString(strTwo)
 	sanitizedStrThree := TibiaDataQueryEscapeString(strThree)
+	sanitizedStrFour := TibiaDataQueryEscapeString(strFour)
 
 	assert := assert.New(t)
 	assert.Equal(sanitizedStrOne, "god+durin")
 	assert.Equal(sanitizedStrTwo, "god+durin")
-	assert.Equal(sanitizedStrThree, "g%F3d")
+	assert.Equal(sanitizedStrThree, "g%C3%B3d")
+	assert.Equal(sanitizedStrFour, "N%C3%A4urin")
 }
 
 func TestDateParser(t *testing.T) {


### PR DESCRIPTION
This pull request updates the string escaping logic in `TibiaDataQueryEscapeString` and its associated tests to improve Unicode handling and simplify encoding. The main change is the removal of the conversion to Latin-1 encoding, allowing proper UTF-8 percent-encoding for non-ASCII characters.

String escaping and encoding improvements:

* Removed the conversion to Latin-1 encoding in `TibiaDataQueryEscapeString`, so strings are now percent-encoded directly in UTF-8, which is the standard for URLs.
* Updated the tests in `TestEscaper` to expect UTF-8 percent-encoded output for non-ASCII characters, and added a new test case for the string `Näurin`.

fix #470 
close #471