### PR TITLE
chore: use splitseq instead of split

### DIFF
--- a/src/TibiaCreaturesCreature.go
+++ b/src/TibiaCreaturesCreature.go
@@ -153,8 +153,8 @@ func TibiaCreaturesCreatureImpl(race string, BoxContentHTML string, url string) 
 		CreatureExperiencePoints = TibiaDataStringToInteger(subma3[0][1])
 		if subma3[0][2] != "nothing" {
 			CreatureIsLootable = true
-			CreatureLootListTmp := strings.Split(strings.Replace(strings.Replace(subma3[0][2], "items ", "", 1), " and sometimes other ", "", 1), ", ")
-			for _, str := range CreatureLootListTmp {
+			CreatureLootListTmp := strings.SplitSeq(strings.Replace(strings.Replace(subma3[0][2], "items ", "", 1), " and sometimes other ", "", 1), ", ")
+			for str := range CreatureLootListTmp {
 				if str != "" {
 					CreatureLootList = append(CreatureLootList, str)
 				}

--- a/src/TibiaGuildsGuild.go
+++ b/src/TibiaGuildsGuild.go
@@ -122,7 +122,7 @@ func TibiaGuildsGuildImpl(guild string, BoxContentHTML string, url string) (Guil
 		return GuildResponse{}, fmt.Errorf("[error] TibiaGuildsGuildImpl failed at InnerTableContainerTMPB ReaderHTML.Find, err: %s", err)
 	}
 
-	for _, line := range strings.Split(strings.TrimSuffix(InnerTableContainerTMPB, "\n"), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSuffix(InnerTableContainerTMPB, "\n"), "\n") {
 		// Guild information
 		if !GuildDescriptionFinished {
 			// First line is the description..

--- a/src/TibiaWorldsWorld.go
+++ b/src/TibiaWorldsWorld.go
@@ -136,8 +136,8 @@ func TibiaWorldsWorldImpl(world string, BoxContentHTML string, url string) (Worl
 
 			if WorldsInformationLeftColumn == "World Quest Titles" {
 				if WorldsInformationRightColumn != "This game world currently has no title." {
-					WorldsQuestTitlesTmp := strings.Split(WorldsInformationRightColumn, ", ")
-					for _, str := range WorldsQuestTitlesTmp {
+					WorldsQuestTitlesTmp := strings.SplitSeq(WorldsInformationRightColumn, ", ")
+					for str := range WorldsQuestTitlesTmp {
 						if str != "" {
 							WorldsQuestTitles = append(WorldsQuestTitles, TibiaDataRemoveURLs(str))
 						}


### PR DESCRIPTION
This pull request updates how string splitting is performed in several functions by replacing usages of `strings.Split` with `strings.SplitSeq`. The change affects list parsing logic in creature loot lists, guild information, and world quest titles, likely to improve handling of input sequences or edge cases. The iteration style in the affected loops is also updated for consistency with the new splitting function.

rel #453