### PR TITLE
fix(ci): specify slug for codecov

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -37,3 +37,4 @@ jobs:
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 #v5.5.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          slug: TibiaData/tibiadata-api-go

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # TibiaData API in Golang
 
 [![GitHub CI](https://img.shields.io/github/actions/workflow/status/tibiadata/tibiadata-api-go/build.yml?branch=main&logo=github)](https://github.com/tibiadata/tibiadata-api-go/actions/workflows/build.yml)
-[![Codecov](https://codecov.io/gh/tibiadata/tibiadata-api-go/branch/main/graph/badge.svg?token=PSBNLBI10C)](https://codecov.io/gh/tibiadata/tibiadata-api-go)
+[![Codecov](https://codecov.io/gh/TibiaData/tibiadata-api-go/branch/main/graph/badge.svg?token=PSBNLBI10C)](https://codecov.io/gh/TibiaData/tibiadata-api-go)
 [![GitHub go.mod version](https://img.shields.io/github/go-mod/go-version/tibiadata/tibiadata-api-go?logo=go)](https://github.com/tibiadata/tibiadata-api-go/blob/main/go.mod)
 [![GitHub release](https://img.shields.io/github/v/release/tibiadata/tibiadata-api-go?sort=semver&logo=github)](https://github.com/tibiadata/tibiadata-api-go/releases)
 [![Docker image size (tag)](https://img.shields.io/docker/image-size/tibiadata/tibiadata-api-go/latest?logo=docker)](https://hub.docker.com/r/tibiadata/tibiadata-api-go)


### PR DESCRIPTION
This pull request makes minor updates to ensure consistency in repository naming for Codecov integration. The Codecov badge and the workflow configuration have both been updated to use the correct, case-sensitive repository slug.