### PR TITLE
revert maintainer codecov guard

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -21,7 +21,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Connect to Tailnet
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository || contains(fromJson('["kamilon", "tobiasehlert"]'), github.actor)
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 #v4.1.2
         with:
           args: --accept-dns=true


### PR DESCRIPTION
Turns out this change isn't actually needed. We do want to keep the manual workflow ability though.