### PR TITLE
remove deprecated rekor-url flag from cosign verify call

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,12 +13,6 @@ on:
     types: [published]
   workflow_dispatch:
 
-permissions:
-  attestations: write
-  contents: read
-  id-token: write
-  packages: write
-
 concurrency:
   group: build-${{ github.workflow }}-${{ github.ref }}
 
@@ -27,6 +21,12 @@ jobs:
     name: build (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
     if: github.event_name != 'pull_request'
+
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
+      packages: write
 
     strategy:
       fail-fast: false
@@ -130,6 +130,12 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
+
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
+      packages: write
 
     outputs:
       docker_build_digest: ${{ steps.docker_build.outputs.digest }}
@@ -261,6 +267,7 @@ jobs:
   argocd:
     if: github.event_name == 'release' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
+    permissions: {}
     needs:
       - build
       - manifest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -242,21 +242,21 @@ jobs:
           docker buildx imagetools inspect ghcr.io/${{ github.repository }}:${{ steps.docker_meta.outputs.version }} --format '{{ json (index .SBOM "linux/amd64") }}'
           echo "::endgroup::"
 
-      # - name: Verify cosign signatures
-      #   run: |
-      #     echo "::group::Verify signature (DockerHub)"
-      #     cosign verify --rekor-url https://rekor.sigstore.dev \
-      #       --certificate-identity "https://github.com/${{ github.workflow_ref }}" \
-      #       --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-      #       ${{ github.repository }}@${{ steps.docker_build.outputs.digest }}
-      #     echo "::endgroup::"
+      - name: Verify cosign signatures
+        run: |
+          echo "::group::Verify signature (DockerHub)"
+          cosign verify \
+            --certificate-identity "https://github.com/${{ github.workflow_ref }}" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            ${{ github.repository }}@${{ steps.docker_build.outputs.digest }}
+          echo "::endgroup::"
 
-      #     echo "::group::Verify signature (GitHub Container Registry)"
-      #     cosign verify --rekor-url https://rekor.sigstore.dev \
-      #       --certificate-identity "https://github.com/${{ github.workflow_ref }}" \
-      #       --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-      #       ghcr.io/${{ github.repository }}@${{ steps.docker_build.outputs.digest }}
-      #     echo "::endgroup::"
+          echo "::group::Verify signature (GitHub Container Registry)"
+          cosign verify \
+            --certificate-identity "https://github.com/${{ github.workflow_ref }}" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            ghcr.io/${{ github.repository }}@${{ steps.docker_build.outputs.digest }}
+          echo "::endgroup::"
 
   argocd:
     if: github.event_name == 'release' || (github.event_name == 'push' && github.ref == 'refs/heads/main')


### PR DESCRIPTION
remove deprecated rekor-url flag from cosign verify call
apply permissions at job level instead of workflow level to reduce blast radius

Should resolve issue: #565 