### PR TITLE
fix(guild): allow 2-character guild names

### DIFF
--- a/src/validation/limits.go
+++ b/src/validation/limits.go
@@ -7,7 +7,7 @@ const (
 	MinRunesAllowedInACharacterNameWord = 1  // Smallest character name word length possible
 
 	MaxRunesAllowedInAGuildName     = 29 // Larggest guild name length possible
-	MinRunesAllowedInAGuildName     = 3  // Smallest guild name length possible
+	MinRunesAllowedInAGuildName     = 2  // Smallest guild name length possible
 	MaxRunesAllowedInAGuildNameWord = 14 // Larggest guild name word length possible
 	MinRunesAllowedInAGuildNameWord = 2  // Smallest character name word length possible
 

--- a/src/validation/validation_test.go
+++ b/src/validation/validation_test.go
@@ -313,6 +313,7 @@ func TestGuildValidator(t *testing.T) {
 		"Hill",
 		"Re Evolution",
 		"On Top",
+		"ab",
 	}
 
 	for _, n := range names {
@@ -328,7 +329,6 @@ func TestGuildValidator(t *testing.T) {
 		"A",
 		"a",
 		"T2wo",
-		"ab",
 		"abc'def",
 	}
 
@@ -341,7 +341,7 @@ func TestGuildValidator(t *testing.T) {
 
 	jsonErrorNames := map[Error]string{
 		ErrorGuildNameEmpty:            "",
-		ErrorGuildNameTooSmall:         "ob",
+		ErrorGuildNameTooSmall:         "a",
 		ErrorGuildNameTooBig:           "abcabcabcabcabcabcabcabcabcabc",
 		ErrorGuildWordTooBig:           "abcabcabcabcabc hello",
 		ErrorGuildNameIsOnlyWhiteSpace: "     ",
@@ -851,7 +851,7 @@ func TestFake(t *testing.T) {
 	assert.Equal(1, MinRunesAllowedInACharacterNameWord)
 
 	assert.Equal(29, MaxRunesAllowedInAGuildName)
-	assert.Equal(3, MinRunesAllowedInAGuildName)
+	assert.Equal(2, MinRunesAllowedInAGuildName)
 	assert.Equal(14, MaxRunesAllowedInAGuildNameWord)
 	assert.Equal(2, MinRunesAllowedInAGuildNameWord)
 


### PR DESCRIPTION
## Problem

The guild lookup endpoint was rejecting valid 2-character guild names. Tibia allows guilds like "No", but the API validation required a minimum of 3 characters, returning a 400 error with "the provided guild name is too small".

## Solution

Updated the minimum allowed guild name length from 3 to 2 characters to align with Tibia's actual rules.

## Changes

- Updated `MinRunesAllowedInAGuildName` constant from 3 to 2 in `src/validation/limits.go`
- Updated validation tests in `src/validation/validation_test.go`:
  - Changed ErrorGuildNameTooSmall test case from "ob" (now valid) to "a" (1 character, still invalid)
  - Moved "ab" from invalid to valid test cases

## Verification

- Guild name validation now accepts 2-character names like "No" and "ab"
- 1-character names are still correctly rejected as too small
- All validation tests pass

Fixes: #663